### PR TITLE
fix: Improve fleet-maintained app inference (#3)

### DIFF
--- a/internal/diff/differ.go
+++ b/internal/diff/differ.go
@@ -178,9 +178,9 @@ func Diff(current *api.FleetState, proposed *parser.ParsedRepo, teamFilters []st
 				// the field is null but the YAML defines fleet-maintained apps,
 				// silently reconstruct the current state from software titles +
 				// the fleet-maintained catalog so we can produce an accurate diff.
-				if currentTeam.Software.FleetMaintained == nil &&
-					len(proposedTeam.Software.FleetMaintained) > 0 {
-					inferred := inferFleetMaintainedApps(currentTeam, current.FleetMaintainedCatalog)
+			if currentTeam.Software.FleetMaintained == nil &&
+				len(proposedTeam.Software.FleetMaintained) > 0 {
+					inferred := inferFleetMaintainedApps(currentTeam, current.FleetMaintainedCatalog, proposedTeam.Software.Packages)
 					currentSoftware.FleetMaintained = inferred // may be nil; that's fine
 				}
 
@@ -599,15 +599,22 @@ func sortResourceChanges(rd *ResourceDiff) {
 	sort.Slice(rd.Deleted, func(i, j int) bool { return byName(rd.Deleted[i], rd.Deleted[j]) })
 }
 
-func inferFleetMaintainedApps(team api.Team, catalog []api.FleetMaintainedApp) []api.TeamFleetApp {
+func inferFleetMaintainedApps(team api.Team, catalog []api.FleetMaintainedApp, proposedPackages []parser.ParsedSoftwarePackage) []api.TeamFleetApp {
 	if len(team.SoftwareTitles) == 0 || len(catalog) == 0 {
 		return nil
 	}
 
-	// When fleet_maintained_apps is null the API merges everything into
-	// team.Software.Packages, so we cannot use package URLs to distinguish
-	// custom packages from fleet-maintained ones. Instead, rely entirely on
-	// catalog-based matching (strategies 1-3 below).
+	// Build exclusion set from YAML-defined custom packages. We cannot use
+	// team.Software.Packages because the API merges fleet-maintained apps
+	// into that list when fleet_maintained_apps is null. The proposed YAML
+	// packages are the authoritative set of custom (non-FMA) software.
+	proposedPkgURLs := make(map[string]bool)
+	for _, p := range proposedPackages {
+		u := normalizeSoftwarePath(p.URL)
+		if u != "" {
+			proposedPkgURLs[u] = true
+		}
+	}
 
 	catalogByAppID := make(map[uint]api.FleetMaintainedApp)
 	catalogByTitleID := make(map[uint]api.FleetMaintainedApp)
@@ -631,6 +638,11 @@ func inferFleetMaintainedApps(team api.Team, catalog []api.FleetMaintainedApp) [
 			continue
 		}
 		if title.SoftwarePackage == nil {
+			continue
+		}
+
+		packageURL := normalizeSoftwarePath(title.SoftwarePackage.PackageURL)
+		if packageURL != "" && proposedPkgURLs[packageURL] {
 			continue
 		}
 

--- a/internal/diff/differ_test.go
+++ b/internal/diff/differ_test.go
@@ -946,6 +946,60 @@ func TestDiffFleetMaintainedAppsInferenceWithMergedPackages(t *testing.T) {
 	}
 }
 
+// TestDiffFleetMaintainedAppsSkipsProposedCustomPackages verifies that titles
+// whose PackageURL matches a proposed custom package are not inferred as
+// fleet-maintained apps (prevents false REMOVED diffs for custom packages
+// that happen to share a name with a catalog entry).
+func TestDiffFleetMaintainedAppsSkipsProposedCustomPackages(t *testing.T) {
+	current := &api.FleetState{
+		FleetMaintainedCatalog: []api.FleetMaintainedApp{
+			{ID: 30, Slug: "gimp/windows", Name: "GIMP", Platform: "windows"},
+		},
+		Teams: []api.Team{
+			{
+				ID: 6, Name: "NVDI",
+				Software: api.TeamSoftware{FleetMaintained: nil},
+				SoftwareTitles: []api.SoftwareTitle{
+					{
+						ID: 99, Name: "GIMP", Source: "programs",
+						SoftwarePackage: &api.SoftwareTitlePackageMeta{
+							PackageURL: "https://download.gimp.org/gimp/v3.0/windows/gimp-3.0.4-setup.exe",
+							Platform:   "windows", SelfService: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	proposed := &parser.ParsedRepo{
+		Teams: []parser.ParsedTeam{
+			{
+				Name: "NVDI",
+				Software: parser.ParsedSoftware{
+					Packages: []parser.ParsedSoftwarePackage{
+						{URL: "https://download.gimp.org/gimp/v3.0/windows/gimp-3.0.4-setup.exe"},
+					},
+					FleetMaintained: []parser.ParsedFleetApp{
+						{Slug: "some-other-app/windows", SelfService: true},
+					},
+				},
+			},
+		},
+	}
+
+	results := Diff(current, proposed, nil, nil)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	for _, d := range r.Software.Deleted {
+		if d.Name == "fleet app gimp/windows" || d.Name == "gimp/windows" {
+			t.Errorf("gimp/windows should NOT appear as deleted (it is a custom package, not FMA)")
+		}
+	}
+}
+
 // TestDiffFleetMaintainedAppsInferenceArchSuffix verifies that inference
 // matches titles whose OS-reported name includes an architecture suffix
 // (e.g., "Notepad++ (64-bit x64)") against catalog entries without it.


### PR DESCRIPTION
## Summary

- Drop the `customPackageURLs` guard that used the API response (which merges FMAs into packages when `fleet_maintained_apps` is null), replace with proposed-YAML-sourced exclusion
- Remove the `source == "apps"` gate so strategies 2 (SoftwareTitleID) and 3 (name matching) work for Windows titles
- Strip common architecture suffixes (e.g., "(64-bit x64)", "(X64)") before name matching as a fallback

Closes #3

## Test plan

- [x] Unit tests for merged-packages scenario
- [x] Unit tests for arch suffix stripping
- [x] Unit tests for custom package exclusion
- [x] Full test suite passes