### PR TITLE
fix: Add prefix matching for FMA catalog name mismatches (#3)

### DIFF
--- a/internal/diff/differ.go
+++ b/internal/diff/differ.go
@@ -619,6 +619,7 @@ func inferFleetMaintainedApps(team api.Team, catalog []api.FleetMaintainedApp, p
 	catalogByAppID := make(map[uint]api.FleetMaintainedApp)
 	catalogByTitleID := make(map[uint]api.FleetMaintainedApp)
 	catalogByNamePlatform := make(map[string][]api.FleetMaintainedApp)
+	catalogByPlatform := make(map[string][]api.FleetMaintainedApp)
 	for _, app := range catalog {
 		if app.ID != 0 {
 			catalogByAppID[app.ID] = app
@@ -629,6 +630,10 @@ func inferFleetMaintainedApps(team api.Team, catalog []api.FleetMaintainedApp, p
 		key := fleetCatalogKey(app.Name, app.Platform)
 		if key != "" {
 			catalogByNamePlatform[key] = append(catalogByNamePlatform[key], app)
+		}
+		plat := normalizeFleetPlatform(app.Platform)
+		if plat != "" {
+			catalogByPlatform[plat] = append(catalogByPlatform[plat], app)
 		}
 	}
 
@@ -675,6 +680,9 @@ func inferFleetMaintainedApps(team api.Team, catalog []api.FleetMaintainedApp, p
 		// Strategy 3: match by name|platform (requires exactly 1 catalog hit).
 		// Windows titles often include arch suffixes (e.g., "Notepad++ (64-bit x64)")
 		// that the catalog omits, so try the raw name first, then stripped.
+		// The catalog uses short marketing names (e.g., "OBS", "Zoom") while the
+		// OS reports full product names (e.g., "OBS Studio", "Zoom Workplace"),
+		// so fall back to prefix matching when exact/stripped matching fails.
 		key := fleetCatalogKey(title.Name, title.SoftwarePackage.Platform)
 		matches := catalogByNamePlatform[key]
 		if len(matches) != 1 {
@@ -683,6 +691,9 @@ func inferFleetMaintainedApps(team api.Team, catalog []api.FleetMaintainedApp, p
 				key = fleetCatalogKey(stripped, title.SoftwarePackage.Platform)
 				matches = catalogByNamePlatform[key]
 			}
+		}
+		if len(matches) != 1 {
+			matches = catalogPrefixMatch(title.Name, title.SoftwarePackage.Platform, catalogByPlatform)
 		}
 		if len(matches) != 1 {
 			continue
@@ -706,6 +717,31 @@ func inferFleetMaintainedApps(team api.Team, catalog []api.FleetMaintainedApp, p
 		out = append(out, app)
 	}
 	return out
+}
+
+// catalogPrefixMatch finds catalog entries whose name is a prefix of the
+// title name on the same platform. Returns matches only when exactly one
+// catalog entry qualifies (ambiguous results are discarded). This handles
+// cases where the catalog uses short marketing names ("OBS", "Zoom") while
+// the OS reports full product names ("OBS Studio", "Zoom Workplace").
+func catalogPrefixMatch(titleName, titlePlatform string, byPlatform map[string][]api.FleetMaintainedApp) []api.FleetMaintainedApp {
+	plat := normalizeFleetPlatform(titlePlatform)
+	candidates := byPlatform[plat]
+	if len(candidates) == 0 {
+		return nil
+	}
+	norm := strings.TrimSpace(strings.ToLower(stripArchSuffix(titleName)))
+	if norm == "" {
+		return nil
+	}
+	var hits []api.FleetMaintainedApp
+	for _, app := range candidates {
+		catName := strings.TrimSpace(strings.ToLower(app.Name))
+		if catName != "" && strings.HasPrefix(norm, catName) {
+			hits = append(hits, app)
+		}
+	}
+	return hits
 }
 
 func fleetCatalogKey(name, platform string) string {

--- a/internal/diff/differ_test.go
+++ b/internal/diff/differ_test.go
@@ -1053,6 +1053,69 @@ func TestDiffFleetMaintainedAppsInferenceArchSuffix(t *testing.T) {
 	}
 }
 
+// TestDiffFleetMaintainedAppsInferencePrefixMatch verifies that inference
+// matches titles whose OS-reported name is longer than the catalog's short
+// marketing name (e.g., "OBS Studio" -> catalog "OBS", "Zoom Workplace" ->
+// catalog "Zoom") via prefix matching.
+func TestDiffFleetMaintainedAppsInferencePrefixMatch(t *testing.T) {
+	current := &api.FleetState{
+		FleetMaintainedCatalog: []api.FleetMaintainedApp{
+			{ID: 50, Slug: "obs/windows", Name: "OBS", Platform: "windows"},
+			{ID: 51, Slug: "zoom/windows", Name: "Zoom", Platform: "windows"},
+		},
+		Teams: []api.Team{
+			{
+				ID: 6, Name: "NVDI",
+				Software: api.TeamSoftware{FleetMaintained: nil},
+				SoftwareTitles: []api.SoftwareTitle{
+					{
+						ID: 16700, Name: "OBS Studio", Source: "programs",
+						SoftwarePackage: &api.SoftwareTitlePackageMeta{
+							PackageURL: "https://github.com/obsproject/obs-studio/releases/download/32.0.4/OBS-Studio-32.0.4-Windows-x64-Installer.exe",
+							Platform:   "windows", SelfService: true,
+						},
+					},
+					{
+						ID: 16731, Name: "Zoom Workplace (X64)", Source: "programs",
+						SoftwarePackage: &api.SoftwareTitlePackageMeta{
+							PackageURL: "https://zoom.us/client/6.7.5.30439/ZoomInstallerFull.msi?archType=x64",
+							Platform:   "windows", SelfService: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	proposed := &parser.ParsedRepo{
+		Teams: []parser.ParsedTeam{
+			{
+				Name: "NVDI",
+				Software: parser.ParsedSoftware{
+					FleetMaintained: []parser.ParsedFleetApp{
+						{Slug: "obs/windows", SelfService: true},
+						{Slug: "zoom/windows", SelfService: true},
+					},
+				},
+			},
+		},
+	}
+
+	results := Diff(current, proposed, nil, nil)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if len(r.Software.Added) != 0 {
+		var slugs []string
+		for _, a := range r.Software.Added {
+			slugs = append(slugs, a.Name)
+		}
+		t.Errorf("expected 0 added (prefix matching should resolve OBS/Zoom), got %d: %v",
+			len(r.Software.Added), slugs)
+	}
+}
+
 // TestDiffProfilesMatchByContentName verifies that profiles are matched by
 // the name extracted from file content (e.g., PayloadDisplayName), not by
 // filename. This is the exact bug that caused false add/delete diffs when


### PR DESCRIPTION
## Summary

- Add prefix matching as a fallback in Strategy 3 of `inferFleetMaintainedApps`
- The Fleet catalog uses short marketing names ("OBS", "Zoom") while the OS reports full product names ("OBS Studio", "Zoom Workplace"). Exact name matching fails for these.
- When exact and arch-suffix-stripped matching both fail, try prefix matching: if exactly one catalog entry's name is a prefix of the title name on the same platform, use it.

Ref #3

## Test plan

- [x] `TestDiffFleetMaintainedAppsInferencePrefixMatch` covers OBS Studio -> OBS and Zoom Workplace (X64) -> Zoom
- [x] Full test suite passes