### PR TITLE
feat: Diff FMA install/uninstall scripts against live Fleet state

### DIFF
--- a/cmd/fleet-plan/main.go
+++ b/cmd/fleet-plan/main.go
@@ -116,7 +116,8 @@ func runDiff(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	results := diff.Diff(state, repo, flagTeams, flagChangedFiles)
+	results := diff.Diff(state, repo, flagTeams, flagChangedFiles,
+		diff.WithScriptEnricher(client))
 	elapsed := time.Since(start)
 
 	hasChanges := output.HasChanges(results)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -144,8 +144,14 @@ type TeamSoftwarePackage struct {
 }
 
 type TeamFleetApp struct {
-	Slug        string `json:"slug"`
-	SelfService bool   `json:"self_service"`
+	Slug              string `json:"slug"`
+	SelfService       bool   `json:"self_service"`
+	TitleID           uint   `json:"-"` // software title ID, for fetching detail
+	TeamID            uint   `json:"-"`
+	InstallScript     string `json:"-"` // populated from title detail endpoint
+	UninstallScript   string `json:"-"`
+	PreInstallQuery   string `json:"-"`
+	PostInstallScript string `json:"-"`
 }
 
 type TeamAppStoreApp struct {
@@ -211,6 +217,25 @@ type SoftwareTitlePackageMeta struct {
 	SelfService          bool   `json:"self_service"`
 	Platform             string `json:"platform"`
 	FleetMaintainedAppID *uint  `json:"fleet_maintained_app_id"`
+}
+
+// SoftwareTitleDetail is the full response from GET /api/v1/fleet/software/titles/:id.
+// It includes script content not available in the list endpoint.
+type SoftwareTitleDetail struct {
+	ID              uint                        `json:"id"`
+	Name            string                      `json:"name"`
+	SoftwarePackage *SoftwareTitleDetailPackage  `json:"software_package"`
+}
+
+// SoftwareTitleDetailPackage contains the full package metadata including scripts.
+type SoftwareTitleDetailPackage struct {
+	InstallScript     string `json:"install_script"`
+	UninstallScript   string `json:"uninstall_script"`
+	PreInstallQuery   string `json:"pre_install_query"`
+	PostInstallScript string `json:"post_install_script"`
+	SelfService       bool   `json:"self_service"`
+	Platform          string `json:"platform"`
+	FleetMaintainedAppID *uint `json:"fleet_maintained_app_id"`
 }
 
 // Label represents a Fleet label.
@@ -388,6 +413,48 @@ func (c *Client) GetSoftware(ctx context.Context, teamID uint) ([]SoftwareTitle,
 		}
 	}
 	return all, nil
+}
+
+// GetSoftwareTitleDetail fetches the full detail for a single software title,
+// including script content not available in the list endpoint.
+func (c *Client) GetSoftwareTitleDetail(ctx context.Context, titleID, teamID uint) (*SoftwareTitleDetail, error) {
+	apiPath := fmt.Sprintf("/api/v1/fleet/software/titles/%d", titleID)
+	q := url.Values{}
+	if teamID > 0 {
+		q.Set("team_id", strconv.FormatUint(uint64(teamID), 10))
+	}
+	var resp struct {
+		SoftwareTitle SoftwareTitleDetail `json:"software_title"`
+	}
+	if err := c.get(ctx, apiPath, q, &resp); err != nil {
+		return nil, fmt.Errorf("fetching software title %d: %w", titleID, err)
+	}
+	return &resp.SoftwareTitle, nil
+}
+
+// EnrichFleetAppScripts fetches title details for FMAs that have a TitleID set
+// and populates their script content. Errors are non-fatal (scripts stay empty).
+func (c *Client) EnrichFleetAppScripts(ctx context.Context, apps []TeamFleetApp) {
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(5)
+	for i := range apps {
+		if apps[i].TitleID == 0 {
+			continue
+		}
+		idx := i
+		g.Go(func() error {
+			detail, err := c.GetSoftwareTitleDetail(gctx, apps[idx].TitleID, apps[idx].TeamID)
+			if err != nil || detail.SoftwarePackage == nil {
+				return nil
+			}
+			apps[idx].InstallScript = strings.TrimSpace(detail.SoftwarePackage.InstallScript)
+			apps[idx].UninstallScript = strings.TrimSpace(detail.SoftwarePackage.UninstallScript)
+			apps[idx].PreInstallQuery = strings.TrimSpace(detail.SoftwarePackage.PreInstallQuery)
+			apps[idx].PostInstallScript = strings.TrimSpace(detail.SoftwarePackage.PostInstallScript)
+			return nil
+		})
+	}
+	g.Wait()
 }
 
 // GetFleetMaintainedApps fetches Fleet's maintained-app catalog.

--- a/internal/diff/differ.go
+++ b/internal/diff/differ.go
@@ -4,6 +4,7 @@
 package diff
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -95,12 +96,35 @@ func matchesAnyTeam(name string, filters []string) bool {
 
 // ---------- Diff engine ----------
 
+// ScriptEnricher fetches script content for inferred fleet-maintained apps.
+// Implementations should populate InstallScript, UninstallScript, etc. on each
+// TeamFleetApp that has a non-zero TitleID.
+type ScriptEnricher interface {
+	EnrichFleetAppScripts(ctx context.Context, apps []api.TeamFleetApp)
+}
+
+// DiffOption configures optional Diff behavior.
+type DiffOption func(*diffOptions)
+
+type diffOptions struct {
+	enricher ScriptEnricher
+}
+
+// WithScriptEnricher enables script-level diffing for fleet-maintained apps.
+func WithScriptEnricher(e ScriptEnricher) DiffOption {
+	return func(o *diffOptions) { o.enricher = e }
+}
+
 // Diff computes the diff between current Fleet state and proposed YAML for all
 // teams. If teamFilters is non-empty, only matching teams are diffed.
 // If changedFiles is non-empty, only resources whose SourceFile matches are
 // included in the output (MR-scoped filtering).
 // Global config from default.yml is diffed when proposed.Global is non-nil.
-func Diff(current *api.FleetState, proposed *parser.ParsedRepo, teamFilters []string, changedFiles []string) []DiffResult {
+func Diff(current *api.FleetState, proposed *parser.ParsedRepo, teamFilters []string, changedFiles []string, opts ...DiffOption) []DiffResult {
+	var cfg diffOptions
+	for _, o := range opts {
+		o(&cfg)
+	}
 	var results []DiffResult
 
 	// Build label lookup from API
@@ -181,7 +205,10 @@ func Diff(current *api.FleetState, proposed *parser.ParsedRepo, teamFilters []st
 			if currentTeam.Software.FleetMaintained == nil &&
 				len(proposedTeam.Software.FleetMaintained) > 0 {
 					inferred := inferFleetMaintainedApps(currentTeam, current.FleetMaintainedCatalog, proposedTeam.Software.Packages)
-					currentSoftware.FleetMaintained = inferred // may be nil; that's fine
+					if cfg.enricher != nil && len(inferred) > 0 {
+						cfg.enricher.EnrichFleetAppScripts(context.Background(), inferred)
+					}
+					currentSoftware.FleetMaintained = inferred
 				}
 
 				result.Software = diffSoftware(currentSoftware, proposedTeam.Software)
@@ -211,13 +238,18 @@ func Diff(current *api.FleetState, proposed *parser.ParsedRepo, teamFilters []st
 	return results
 }
 
-func buildSourceMap(team parser.ParsedTeam) map[string]string {
-	m := make(map[string]string)
+func buildSourceMap(team parser.ParsedTeam) map[string][]string {
+	m := make(map[string][]string)
+	add := func(name, src string) {
+		if name != "" && src != "" {
+			m[name] = append(m[name], src)
+		}
+	}
 	for _, p := range team.Policies {
-		m[p.Name] = p.SourceFile
+		add(p.Name, p.SourceFile)
 	}
 	for _, q := range team.Queries {
-		m[q.Name] = q.SourceFile
+		add(q.Name, q.SourceFile)
 	}
 	for _, p := range team.Software.Packages {
 		key := normalizeSoftwarePath(p.RefPath)
@@ -228,30 +260,37 @@ func buildSourceMap(team parser.ParsedTeam) map[string]string {
 			key = normalizeSoftwarePath(p.URL)
 		}
 		if key != "" {
-			m[normalizeSoftwarePath(key)] = p.SourceFile
+			add(normalizeSoftwarePath(key), p.SourceFile)
 		}
 	}
 	for _, f := range team.Software.FleetMaintained {
 		slug := normalizeSoftwarePath(f.Slug)
-		if slug != "" {
-			m["fleet app "+slug] = team.SourceFile
+		if slug == "" {
+			continue
+		}
+		name := "fleet app " + slug
+		add(name, team.SourceFile)
+		for _, sf := range f.SourceFiles {
+			add(name, sf)
 		}
 	}
 	for _, p := range team.Profiles {
-		m[p.Name] = p.SourceFile
+		add(p.Name, p.SourceFile)
 	}
 	return m
 }
 
-func filterResourceDiff(rd ResourceDiff, sourceNames map[string]string, changedFiles []string) ResourceDiff {
+func filterResourceDiff(rd ResourceDiff, sourceNames map[string][]string, changedFiles []string) ResourceDiff {
 	match := func(name string) bool {
-		src, ok := sourceNames[name]
+		srcs, ok := sourceNames[name]
 		if !ok {
 			return true
 		}
-		for _, cf := range changedFiles {
-			if src == cf || strings.HasSuffix(src, "/"+cf) {
-				return true
+		for _, src := range srcs {
+			for _, cf := range changedFiles {
+				if src == cf || strings.HasSuffix(src, "/"+cf) {
+					return true
+				}
 			}
 		}
 		return false
@@ -501,15 +540,33 @@ func diffSoftware(current api.TeamSoftware, proposed parser.ParsedSoftware) Reso
 				})
 				continue
 			}
+			fields := make(map[string]FieldDiff)
 			if cur.SelfService != a.SelfService {
+				fields["self_service"] = FieldDiff{
+					Old: fmt.Sprint(cur.SelfService),
+					New: fmt.Sprint(a.SelfService),
+				}
+			}
+			if cur.InstallScript != "" && a.InstallScript != "" &&
+				normalizeWS(cur.InstallScript) != normalizeWS(a.InstallScript) {
+				fields["install_script"] = FieldDiff{Old: cur.InstallScript, New: a.InstallScript}
+			}
+			if cur.UninstallScript != "" && a.UninstallScript != "" &&
+				normalizeWS(cur.UninstallScript) != normalizeWS(a.UninstallScript) {
+				fields["uninstall_script"] = FieldDiff{Old: cur.UninstallScript, New: a.UninstallScript}
+			}
+			if cur.PreInstallQuery != "" && a.PreInstallQuery != "" &&
+				normalizeWS(cur.PreInstallQuery) != normalizeWS(a.PreInstallQuery) {
+				fields["pre_install_query"] = FieldDiff{Old: cur.PreInstallQuery, New: a.PreInstallQuery}
+			}
+			if cur.PostInstallScript != "" && a.PostInstallScript != "" &&
+				normalizeWS(cur.PostInstallScript) != normalizeWS(a.PostInstallScript) {
+				fields["post_install_script"] = FieldDiff{Old: cur.PostInstallScript, New: a.PostInstallScript}
+			}
+			if len(fields) > 0 {
 				rd.Modified = append(rd.Modified, ResourceChange{
-					Name: "fleet app " + slug,
-					Fields: map[string]FieldDiff{
-						"self_service": {
-							Old: fmt.Sprint(cur.SelfService),
-							New: fmt.Sprint(a.SelfService),
-						},
-					},
+					Name:   "fleet app " + slug,
+					Fields: fields,
 				})
 			}
 		}
@@ -651,15 +708,21 @@ func inferFleetMaintainedApps(team api.Team, catalog []api.FleetMaintainedApp, p
 			continue
 		}
 
+		record := func(slug string) {
+			inferred[slug] = api.TeamFleetApp{
+				Slug:        slug,
+				SelfService: title.SoftwarePackage.SelfService,
+				TitleID:     title.ID,
+				TeamID:      team.ID,
+			}
+		}
+
 		// Strategy 1: match by fleet_maintained_app_id (exact, from API).
 		if title.SoftwarePackage.FleetMaintainedAppID != nil {
 			if app, ok := catalogByAppID[*title.SoftwarePackage.FleetMaintainedAppID]; ok {
 				slug := normalizeSoftwarePath(app.Slug)
 				if slug != "" {
-					inferred[slug] = api.TeamFleetApp{
-						Slug:        slug,
-						SelfService: title.SoftwarePackage.SelfService,
-					}
+					record(slug)
 					continue
 				}
 			}
@@ -669,10 +732,7 @@ func inferFleetMaintainedApps(team api.Team, catalog []api.FleetMaintainedApp, p
 		if app, ok := catalogByTitleID[title.ID]; ok {
 			slug := normalizeSoftwarePath(app.Slug)
 			if slug != "" {
-				inferred[slug] = api.TeamFleetApp{
-					Slug:        slug,
-					SelfService: title.SoftwarePackage.SelfService,
-				}
+				record(slug)
 				continue
 			}
 		}
@@ -703,10 +763,7 @@ func inferFleetMaintainedApps(team api.Team, catalog []api.FleetMaintainedApp, p
 		if slug == "" {
 			continue
 		}
-		inferred[slug] = api.TeamFleetApp{
-			Slug:        slug,
-			SelfService: title.SoftwarePackage.SelfService,
-		}
+		record(slug)
 	}
 
 	if len(inferred) == 0 {

--- a/internal/diff/differ_test.go
+++ b/internal/diff/differ_test.go
@@ -57,6 +57,9 @@ func TestDiffTestdataAgainstMockAPI(t *testing.T) {
 						// old-agent: not in YAML → deleted
 						{ReferencedYAMLPath: "software/mac/old-agent/old-agent.yml", URL: "https://example.com/old-agent.pkg"},
 					},
+					FleetMaintained: []api.TeamFleetApp{
+						{Slug: "cursor/windows", SelfService: true},
+					},
 				},
 				// Profile uses PayloadDisplayName "fleet_orbit-allowfulldiskaccess"
 				// which matches the content of the .mobileconfig file (not the filename).
@@ -1113,6 +1116,62 @@ func TestDiffFleetMaintainedAppsInferencePrefixMatch(t *testing.T) {
 		}
 		t.Errorf("expected 0 added (prefix matching should resolve OBS/Zoom), got %d: %v",
 			len(r.Software.Added), slugs)
+	}
+}
+
+// TestDiffFleetMaintainedAppsScriptChange verifies that when an FMA's install
+// script content changes, the diff reports it as modified.
+func TestDiffFleetMaintainedAppsScriptChange(t *testing.T) {
+	current := &api.FleetState{
+		FleetMaintainedCatalog: []api.FleetMaintainedApp{
+			{ID: 10, Slug: "cursor/windows", Name: "Cursor", Platform: "windows"},
+		},
+		Teams: []api.Team{
+			{
+				ID: 6, Name: "NVDI",
+				Software: api.TeamSoftware{
+					FleetMaintained: []api.TeamFleetApp{
+						{
+							Slug:          "cursor/windows",
+							SelfService:   true,
+							InstallScript: "old-install-script",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	proposed := &parser.ParsedRepo{
+		Teams: []parser.ParsedTeam{
+			{
+				Name: "NVDI",
+				Software: parser.ParsedSoftware{
+					FleetMaintained: []parser.ParsedFleetApp{
+						{
+							Slug:          "cursor/windows",
+							SelfService:   true,
+							InstallScript: "new-install-script",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	results := Diff(current, proposed, nil, nil)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if len(r.Software.Modified) != 1 {
+		t.Fatalf("expected 1 modified FMA, got %d (added=%d)", len(r.Software.Modified), len(r.Software.Added))
+	}
+	if r.Software.Modified[0].Name != "fleet app cursor/windows" {
+		t.Errorf("unexpected modified name: %q", r.Software.Modified[0].Name)
+	}
+	if _, ok := r.Software.Modified[0].Fields["install_script"]; !ok {
+		t.Error("expected install_script field diff")
 	}
 }
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -147,8 +147,13 @@ type ParsedSoftwarePackage struct {
 
 // ParsedFleetApp represents a Fleet-maintained app.
 type ParsedFleetApp struct {
-	Slug        string `yaml:"slug"`
-	SelfService bool   `yaml:"self_service"`
+	Slug              string   `yaml:"slug"`
+	SelfService       bool     `yaml:"self_service"`
+	InstallScript     string   `yaml:"-"` // resolved file content
+	UninstallScript   string   `yaml:"-"`
+	PreInstallQuery   string   `yaml:"-"`
+	PostInstallScript string   `yaml:"-"`
+	SourceFiles       []string `yaml:"-"` // all referenced file paths (for changed-file filtering)
 }
 
 // ParsedAppStoreApp represents an App Store app.
@@ -209,8 +214,17 @@ type rawPathRef struct {
 
 type rawSoftwareBlock struct {
 	Packages        []rawSoftwareRef    `yaml:"packages"`
-	FleetMaintained []ParsedFleetApp    `yaml:"fleet_maintained_apps"`
+	FleetMaintained []rawFleetApp       `yaml:"fleet_maintained_apps"`
 	AppStoreApps    []ParsedAppStoreApp `yaml:"app_store_apps"`
+}
+
+type rawFleetApp struct {
+	Slug              string       `yaml:"slug"`
+	SelfService       bool         `yaml:"self_service"`
+	InstallScript     *rawPathRef  `yaml:"install_script"`
+	UninstallScript   *rawPathRef  `yaml:"uninstall_script"`
+	PreInstallQuery   *rawPathRef  `yaml:"pre_install_query"`
+	PostInstallScript *rawPathRef  `yaml:"post_install_script"`
 }
 
 type rawSoftwareRef struct {
@@ -388,7 +402,11 @@ func parseTeamFile(path string) (*ParsedTeam, []ParseError) {
 			team.Software.Packages = append(team.Software.Packages, pkgs[i])
 		}
 	}
-	team.Software.FleetMaintained = raw.Software.FleetMaintained
+	for _, rawFMA := range raw.Software.FleetMaintained {
+		fma, fmaErrs := resolveFleetApp(dir, rawFMA, path)
+		errs = append(errs, fmaErrs...)
+		team.Software.FleetMaintained = append(team.Software.FleetMaintained, fma)
+	}
 	team.Software.AppStoreApps = raw.Software.AppStoreApps
 
 	// Resolve profile paths and extract names from file content.
@@ -517,6 +535,54 @@ func resolveSoftwareRef(baseDir, refPath, parentFile string) ([]ParsedSoftwarePa
 	}
 	pkg.SourceFile = resolved
 	return []ParsedSoftwarePackage{pkg}, nil
+}
+
+// resolveFleetApp resolves path: references in a fleet-maintained app entry,
+// reading script and query file content. Non-fatal: missing optional files are
+// logged as parse errors but the FMA is still returned.
+func resolveFleetApp(baseDir string, raw rawFleetApp, parentFile string) (ParsedFleetApp, []ParseError) {
+	var errs []ParseError
+	fma := ParsedFleetApp{
+		Slug:        raw.Slug,
+		SelfService: raw.SelfService,
+	}
+
+	readScript := func(ref *rawPathRef, label string) string {
+		if ref == nil || ref.Path == "" {
+			return ""
+		}
+		data, resolved, readErrs := readYAMLRef(baseDir, ref.Path, parentFile, label+" ")
+		if readErrs != nil {
+			errs = append(errs, readErrs...)
+			return ""
+		}
+		fma.SourceFiles = append(fma.SourceFiles, resolved)
+		return strings.TrimSpace(string(data))
+	}
+
+	fma.InstallScript = readScript(raw.InstallScript, "install_script")
+	fma.UninstallScript = readScript(raw.UninstallScript, "uninstall_script")
+	fma.PostInstallScript = readScript(raw.PostInstallScript, "post_install_script")
+
+	if raw.PreInstallQuery != nil && raw.PreInstallQuery.Path != "" {
+		data, resolved, readErrs := readYAMLRef(baseDir, raw.PreInstallQuery.Path, parentFile, "pre_install_query ")
+		if readErrs != nil {
+			errs = append(errs, readErrs...)
+		} else {
+			fma.SourceFiles = append(fma.SourceFiles, resolved)
+			// The query file may contain a YAML query definition or raw SQL.
+			var q struct {
+				Query string `yaml:"query"`
+			}
+			if yaml.Unmarshal(data, &q) == nil && q.Query != "" {
+				fma.PreInstallQuery = q.Query
+			} else {
+				fma.PreInstallQuery = strings.TrimSpace(string(data))
+			}
+		}
+	}
+
+	return fma, errs
 }
 
 // normalizeSoftwareRefPath canonicalizes teams/*.yml software package paths so

--- a/testdata/software/windows/cursor/install.ps1
+++ b/testdata/software/windows/cursor/install.ps1
@@ -1,0 +1,3 @@
+Import-Module NVHelpers -Force -ErrorAction Stop
+$exit_code = Invoke-Binary $env:INSTALLER_PATH @('/VERYSILENT')
+exit $exit_code

--- a/testdata/software/windows/cursor/uninstall.ps1
+++ b/testdata/software/windows/cursor/uninstall.ps1
@@ -1,0 +1,7 @@
+Import-Module NVHelpers -Force -ErrorAction Stop
+$app = 'cursor'
+$uninstall_strings = Find-UninstallString -Name $app
+foreach ($uninstall_string in $uninstall_strings) {
+  $exit_code = Invoke-Binary $uninstall_string @('/VERYSILENT')
+}
+exit $exit_code

--- a/testdata/teams/workstations.yml
+++ b/testdata/teams/workstations.yml
@@ -24,3 +24,10 @@ software:
     - path: ../software/mac/slack/slack.yml
     - path: ../software/windows/example-app/example-app.yml
       self_service: true
+  fleet_maintained_apps:
+    - slug: cursor/windows
+      install_script:
+        path: ../software/windows/cursor/install.ps1
+      uninstall_script:
+        path: ../software/windows/cursor/uninstall.ps1
+      self_service: true


### PR DESCRIPTION
## Summary

- Parse `install_script`, `uninstall_script`, `pre_install_query`, and `post_install_script` path refs from `fleet_maintained_apps` YAML entries
- Resolve file content during parsing, fetch current script content from the `/api/v1/fleet/software/titles/:id` detail endpoint
- Compare script content in the differ, show as MODIFIED when scripts change
- Update the changed-file source map so MR-scoped filtering includes FMA script files

Previously, `fleet-plan` only tracked `slug` and `self_service` for FMAs. Script changes (like updating `cursor/install.ps1`) were invisible.

## Test plan

- [x] `TestDiffFleetMaintainedAppsScriptChange`
- [x] Integration test with testdata FMA entry
- [x] Full test suite passes
- [ ] Verify via fleet-gitops MR !1047 pipeline