### PR TITLE
fix: Escape pipes and newlines in markdown table cells

### DIFF
--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -165,10 +165,19 @@ func mdCodeSpan(s string) string {
 	if s == "" {
 		return "_(empty)_"
 	}
+	s = mdEscapeTableCell(s)
 	if !strings.Contains(s, "`") {
 		return "`" + s + "`"
 	}
 	return "`` " + s + " ``"
+}
+
+// mdEscapeTableCell escapes characters that break markdown table cells.
+func mdEscapeTableCell(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "|", "\\|")
+	return s
 }
 
 func mdFieldDetails(fields map[string]diff.FieldDiff) string {

--- a/internal/output/markdown_test.go
+++ b/internal/output/markdown_test.go
@@ -277,6 +277,24 @@ func TestRenderDiffMarkdown(t *testing.T) {
 			wantAll: []string{"26,782"},
 		},
 		{
+			name: "pipes and newlines escaped in table cells",
+			results: []diff.DiffResult{{
+				Team: "T",
+				Software: diff.ResourceDiff{
+					Modified: []diff.ResourceChange{{
+						Name: "fleet app cursor/windows",
+						Fields: map[string]diff.FieldDiff{
+							"install_script": {
+								Old: "$exit_code = Invoke-Binary $env:INSTALLER_PATH\nexit $exit_code",
+								New: "try { $result = Invoke-AsLoggedInUser | Out-Null }\nexit 0",
+							},
+						},
+					}},
+				},
+			}},
+			wantAll: []string{`\|`, "Invoke-AsLoggedInUser"},
+		},
+		{
 			name: "long field values truncated",
 			results: []diff.DiffResult{{
 				Team: "T",


### PR DESCRIPTION
## Summary

Script diff content containing `|` (pipe) and newline characters broke the markdown table rendering in MR comments. Pipes are now escaped as `\|` and newlines replaced with spaces before wrapping in code spans.

## Test plan

- [x] New test: pipes and newlines escaped in table cells
- [x] Full test suite passes
- [ ] Verify via fleet-gitops MR !1047 pipeline