### PR TITLE
fix: Track script source files in changed-file filter

### DIFF
--- a/internal/diff/differ.go
+++ b/internal/diff/differ.go
@@ -259,6 +259,9 @@ func buildSourceMap(team parser.ParsedTeam) map[string][]string {
 		}
 		if key != "" {
 			add(normalizeSoftwarePath(key), p.SourceFile)
+			for _, sf := range p.SourceFiles {
+				add(normalizeSoftwarePath(key), sf)
+			}
 		}
 	}
 	for _, f := range team.Software.FleetMaintained {

--- a/internal/diff/differ_test.go
+++ b/internal/diff/differ_test.go
@@ -1453,6 +1453,127 @@ func TestStripArchSuffix(t *testing.T) {
 	}
 }
 
+// TestDiffChangedFileFilterIncludesScriptSourceFiles verifies that when only a
+// script file changes (no YAML changes), the changed-file filter still includes
+// the parent software package in the diff output. Regression test for #11.
+func TestDiffChangedFileFilterIncludesScriptSourceFiles(t *testing.T) {
+	current := &api.FleetState{
+		Teams: []api.Team{
+			{
+				ID:   1,
+				Name: "Workstations",
+				Software: api.TeamSoftware{
+					Packages: []api.TeamSoftwarePackage{
+						{
+							ReferencedYAMLPath: "software/mac/printers-hq/printers-hq.yml",
+							URL:                "https://example.com/printers-hq-1.0.pkg",
+						},
+						{
+							ReferencedYAMLPath: "software/mac/slack/slack.yml",
+							URL:                "https://example.com/slack-old.dmg",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	proposed := &parser.ParsedRepo{
+		Teams: []parser.ParsedTeam{
+			{
+				Name: "Workstations",
+				Software: parser.ParsedSoftware{
+					Packages: []parser.ParsedSoftwarePackage{
+						{
+							RefPath:    "software/mac/printers-hq/printers-hq.yml",
+							URL:        "https://example.com/printers-hq-2.0.pkg",
+							SourceFile: "/repo/software/mac/printers-hq/printers-hq.yml",
+							SourceFiles: []string{
+								"/repo/software/mac/printers-hq/printers-hq-install.sh",
+								"/repo/software/mac/printers-hq/printers-hq-uninstall.sh",
+							},
+						},
+						{
+							RefPath:    "software/mac/slack/slack.yml",
+							URL:        "https://example.com/slack-new.dmg",
+							SourceFile: "/repo/software/mac/slack/slack.yml",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Only the install script changed, no YAML changes.
+	changedFiles := []string{
+		"software/mac/printers-hq/printers-hq-install.sh",
+	}
+
+	results := Diff(current, proposed, nil, changedFiles)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+
+	// printers-hq should appear (its install script is in changedFiles).
+	if len(r.Software.Modified) != 1 {
+		t.Fatalf("expected 1 modified package (printers-hq via script match), got %d modified, %d added, %d deleted",
+			len(r.Software.Modified), len(r.Software.Added), len(r.Software.Deleted))
+	}
+	if !strings.Contains(r.Software.Modified[0].Name, "printers-hq") {
+		t.Errorf("expected printers-hq in modified, got %q", r.Software.Modified[0].Name)
+	}
+
+	// slack should be filtered out (its YAML is not in changedFiles).
+	for _, m := range r.Software.Modified {
+		if strings.Contains(m.Name, "slack") {
+			t.Errorf("slack should be filtered out, but found in modified: %q", m.Name)
+		}
+	}
+}
+
+// TestDiffChangedFileFilterYAMLStillWorks verifies that the changed-file filter
+// continues to work for YAML-only changes (no regression from script tracking).
+func TestDiffChangedFileFilterYAMLStillWorks(t *testing.T) {
+	current := &api.FleetState{
+		Teams: []api.Team{
+			{
+				ID:   1,
+				Name: "T",
+				Software: api.TeamSoftware{
+					Packages: []api.TeamSoftwarePackage{
+						{ReferencedYAMLPath: "software/mac/app/app.yml", URL: "https://example.com/old.pkg"},
+					},
+				},
+			},
+		},
+	}
+
+	proposed := &parser.ParsedRepo{
+		Teams: []parser.ParsedTeam{
+			{
+				Name: "T",
+				Software: parser.ParsedSoftware{
+					Packages: []parser.ParsedSoftwarePackage{
+						{
+							RefPath:     "software/mac/app/app.yml",
+							URL:         "https://example.com/new.pkg",
+							SourceFile:  "/repo/software/mac/app/app.yml",
+							SourceFiles: []string{"/repo/software/mac/app/install.sh"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	results := Diff(current, proposed, nil, []string{"software/mac/app/app.yml"})
+	r := results[0]
+	if len(r.Software.Modified) != 1 {
+		t.Fatalf("expected 1 modified (YAML match), got %d", len(r.Software.Modified))
+	}
+}
+
 // findTeam locates a DiffResult by team name, failing the test if not found.
 func findTeam(t *testing.T, results []DiffResult, name string) *DiffResult {
 	t.Helper()

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -138,11 +138,12 @@ type ParsedSoftware struct {
 
 // ParsedSoftwarePackage represents a custom software package.
 type ParsedSoftwarePackage struct {
-	URL         string `yaml:"url"`
-	HashSHA256  string `yaml:"hash_sha256"`
-	SelfService bool   `yaml:"self_service"`
-	SourceFile  string `yaml:"-"`
-	RefPath     string `yaml:"-"`
+	URL         string   `yaml:"url"`
+	HashSHA256  string   `yaml:"hash_sha256"`
+	SelfService bool     `yaml:"self_service"`
+	SourceFile  string   `yaml:"-"`
+	RefPath     string   `yaml:"-"`
+	SourceFiles []string `yaml:"-"` // all referenced file paths (install/uninstall scripts, pre_install_query)
 }
 
 // ParsedFleetApp represents a Fleet-maintained app.
@@ -230,6 +231,17 @@ type rawFleetApp struct {
 type rawSoftwareRef struct {
 	Path        string `yaml:"path"`
 	SelfService *bool  `yaml:"self_service"`
+}
+
+// rawSoftwarePackage captures script path: refs inside a software package YAML file.
+type rawSoftwarePackage struct {
+	URL               string      `yaml:"url"`
+	HashSHA256        string      `yaml:"hash_sha256"`
+	SelfService       bool        `yaml:"self_service"`
+	InstallScript     *rawPathRef `yaml:"install_script"`
+	UninstallScript   *rawPathRef `yaml:"uninstall_script"`
+	PreInstallQuery   *rawPathRef `yaml:"pre_install_query"`
+	PostInstallScript *rawPathRef `yaml:"post_install_script"`
 }
 
 type rawControls struct {
@@ -522,19 +534,44 @@ func resolveQueryRef(baseDir, refPath, parentFile string) ([]ParsedQuery, []Pars
 	return items, nil
 }
 
-// resolveSoftwareRef reads a software package YAML file.
+// resolveSoftwareRef reads a software package YAML file and resolves any
+// install_script, uninstall_script, pre_install_query, or post_install_script
+// path: references within it. The resolved paths are tracked in SourceFiles
+// so the changed-file filter can match script-only MR changes.
 func resolveSoftwareRef(baseDir, refPath, parentFile string) ([]ParsedSoftwarePackage, []ParseError) {
 	data, resolved, errs := readYAMLRef(baseDir, refPath, parentFile, "software ")
 	if errs != nil {
 		return nil, errs
 	}
 
-	var pkg ParsedSoftwarePackage
-	if err := yaml.Unmarshal(data, &pkg); err != nil {
+	var raw rawSoftwarePackage
+	if err := yaml.Unmarshal(data, &raw); err != nil {
 		return nil, []ParseError{{File: resolved, Message: fmt.Sprintf("YAML parse error: %s", err)}}
 	}
-	pkg.SourceFile = resolved
-	return []ParsedSoftwarePackage{pkg}, nil
+
+	pkg := ParsedSoftwarePackage{
+		URL:         raw.URL,
+		HashSHA256:  raw.HashSHA256,
+		SelfService: raw.SelfService,
+		SourceFile:  resolved,
+	}
+
+	pkgDir := filepath.Dir(resolved)
+	for _, ref := range []*rawPathRef{raw.InstallScript, raw.UninstallScript, raw.PreInstallQuery, raw.PostInstallScript} {
+		if ref == nil || ref.Path == "" {
+			continue
+		}
+		scriptPath := filepath.Join(pkgDir, ref.Path)
+		if repoRoot != "" {
+			if err := safePath(repoRoot, scriptPath); err != nil {
+				errs = append(errs, ParseError{File: resolved, Message: err.Error()})
+				continue
+			}
+		}
+		pkg.SourceFiles = append(pkg.SourceFiles, scriptPath)
+	}
+
+	return []ParsedSoftwarePackage{pkg}, errs
 }
 
 // resolveFleetApp resolves path: references in a fleet-maintained app entry,

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -523,6 +523,57 @@ func TestValidateLogging(t *testing.T) {
 	}
 }
 
+// TestParseSoftwarePackageScriptSourceFiles verifies that install_script,
+// uninstall_script, and other path: refs inside a software package YAML are
+// resolved and tracked in SourceFiles. This enables the changed-file filter
+// to match MRs that only modify scripts (no YAML changes).
+func TestParseSoftwarePackageScriptSourceFiles(t *testing.T) {
+	root := testutil.TestdataRoot(t)
+
+	repo, err := ParseRepo(root, []string{"Workstations"}, "")
+	if err != nil {
+		t.Fatalf("ParseRepo: %v", err)
+	}
+	if len(repo.Errors) > 0 {
+		for _, e := range repo.Errors {
+			t.Logf("parse error: %s", e)
+		}
+		t.Fatalf("expected zero parse errors, got %d", len(repo.Errors))
+	}
+
+	ws := &repo.Teams[0]
+	var exApp *ParsedSoftwarePackage
+	for i := range ws.Software.Packages {
+		if strings.Contains(ws.Software.Packages[i].RefPath, "example-app") {
+			exApp = &ws.Software.Packages[i]
+			break
+		}
+	}
+	if exApp == nil {
+		t.Fatal("example-app package not found")
+	}
+
+	if len(exApp.SourceFiles) != 2 {
+		t.Fatalf("expected 2 SourceFiles (install.ps1, uninstall.ps1), got %d: %v", len(exApp.SourceFiles), exApp.SourceFiles)
+	}
+
+	hasInstall, hasUninstall := false, false
+	for _, sf := range exApp.SourceFiles {
+		if strings.HasSuffix(sf, "install.ps1") && !strings.Contains(sf, "uninstall") {
+			hasInstall = true
+		}
+		if strings.HasSuffix(sf, "uninstall.ps1") {
+			hasUninstall = true
+		}
+	}
+	if !hasInstall {
+		t.Errorf("expected install.ps1 in SourceFiles, got %v", exApp.SourceFiles)
+	}
+	if !hasUninstall {
+		t.Errorf("expected uninstall.ps1 in SourceFiles, got %v", exApp.SourceFiles)
+	}
+}
+
 // TestParseRepoDuplicateSoftwareRefs verifies duplicate software ref detection.
 func TestParseRepoDuplicateSoftwareRefs(t *testing.T) {
 	root := t.TempDir()

--- a/testdata/software/windows/example-app/example-app.yml
+++ b/testdata/software/windows/example-app/example-app.yml
@@ -1,3 +1,7 @@
 url: https://downloads.example.com/example-app-2.0.msi
 hash_sha256: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
 self_service: false
+install_script:
+  path: install.ps1
+uninstall_script:
+  path: uninstall.ps1

--- a/testdata/software/windows/example-app/install.ps1
+++ b/testdata/software/windows/example-app/install.ps1
@@ -1,0 +1,2 @@
+$installer = "$env:INSTALLER_PATH"
+Start-Process msiexec.exe -ArgumentList "/i `"$installer`" /qn /norestart" -Wait

--- a/testdata/software/windows/example-app/uninstall.ps1
+++ b/testdata/software/windows/example-app/uninstall.ps1
@@ -1,0 +1,2 @@
+$app = Get-WmiObject -Class Win32_Product | Where-Object { $_.Name -match "Example App" }
+if ($app) { $app.Uninstall() }


### PR DESCRIPTION
## Summary

- Resolves `install_script`, `uninstall_script`, `pre_install_query`, and `post_install_script` path refs inside software package YAML during parsing
- Tracks resolved script paths in `ParsedSoftwarePackage.SourceFiles`
- Includes script source files in `buildSourceMap` so the `--changed-file` filter matches script-only MR changes

Closes #11

## Test plan

- [x] New parser test: `TestParseSoftwarePackageScriptSourceFiles`
- [x] New differ test: `TestDiffChangedFileFilterIncludesScriptSourceFiles`
- [x] New differ test: `TestDiffChangedFileFilterYAMLStillWorks`
- [x] All existing tests pass