### PR TITLE
feat: Diff controls.scripts (add/delete detection)

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -123,9 +123,11 @@ type Team struct {
 	Policies              []Policy
 	Queries               []Query
 	Profiles              []Profile // populated by GetProfiles
+	Scripts               []Script  // populated by GetScripts
 	SoftwareTitles        []SoftwareTitle
 	SoftwareUnavailable   bool // true when GetSoftware returned 403/404 (token lacks permission)
 	ProfilesUnavailable   bool // true when GetProfiles returned 403/404 (token lacks permission)
+	ScriptsUnavailable    bool // true when GetScripts returned 403/404 (token lacks permission)
 }
 
 // TeamSoftware mirrors /api/v1/fleet/teams[].software for managed software
@@ -254,6 +256,13 @@ type Profile struct {
 	Platform    string `json:"platform"`
 }
 
+// Script represents a Fleet script assigned to a team.
+type Script struct {
+	ID     uint   `json:"id"`
+	Name   string `json:"name"`
+	TeamID uint   `json:"team_id"`
+}
+
 // ---------- API response wrappers ----------
 
 type teamsResponse struct {
@@ -281,6 +290,13 @@ type labelsResponse struct {
 
 type profilesResponse struct {
 	Profiles []Profile `json:"profiles"`
+}
+
+type scriptsResponse struct {
+	Scripts []Script `json:"scripts"`
+	Meta    struct {
+		HasNextResults bool `json:"has_next_results"`
+	} `json:"meta"`
 }
 
 type fleetMaintainedAppsResponse struct {
@@ -521,6 +537,34 @@ func (c *Client) GetProfiles(ctx context.Context, teamID uint) ([]Profile, error
 	return resp.Profiles, nil
 }
 
+// GetScripts fetches scripts for a team with pagination.
+func (c *Client) GetScripts(ctx context.Context, teamID uint) ([]Script, error) {
+	var all []Script
+	page := 0
+	for {
+		q := url.Values{
+			"per_page": {"250"},
+			"page":     {strconv.Itoa(page)},
+		}
+		if teamID > 0 {
+			q.Set("team_id", strconv.FormatUint(uint64(teamID), 10))
+		}
+		var resp scriptsResponse
+		if err := c.get(ctx, "/api/v1/fleet/scripts", q, &resp); err != nil {
+			return nil, fmt.Errorf("fetching scripts (team %d): %w", teamID, err)
+		}
+		all = append(all, resp.Scripts...)
+		if !resp.Meta.HasNextResults || len(resp.Scripts) == 0 {
+			break
+		}
+		page++
+		if page > 100 { // safety: max 25k scripts
+			break
+		}
+	}
+	return all, nil
+}
+
 // FetchAll concurrently fetches the complete Fleet state. Uses errgroup for
 // parallel requests. If fetchGlobal is true, also fetches global config,
 // policies, and queries (for default.yml diffing).
@@ -627,6 +671,19 @@ func (c *Client) FetchAll(ctx context.Context, fetchGlobal ...bool) (*FleetState
 				softwareTitles = nil
 			}
 			teamResults[idx].SoftwareTitles = softwareTitles
+			return nil
+		})
+
+		g.Go(func() error {
+			scripts, err := c.GetScripts(gctx, teamID)
+			if err != nil {
+				if !isPermissionError(err) {
+					return err
+				}
+				teamResults[idx].ScriptsUnavailable = true
+				scripts = nil
+			}
+			teamResults[idx].Scripts = scripts
 			return nil
 		})
 	}

--- a/internal/diff/differ.go
+++ b/internal/diff/differ.go
@@ -27,6 +27,7 @@ type DiffResult struct {
 	Queries              ResourceDiff
 	Software             ResourceDiff
 	Profiles             ResourceDiff
+	Scripts              ResourceDiff
 	Labels               LabelValidation
 	Config               []ConfigChange // org_settings, agent_options, controls diffs
 	Errors               []string
@@ -219,6 +220,12 @@ func Diff(current *api.FleetState, proposed *parser.ParsedRepo, teamFilters []st
 				result.Profiles, profileWarnings = diffProfiles(currentTeam.Profiles, proposedTeam.Profiles)
 				result.Errors = append(result.Errors, profileWarnings...)
 			}
+
+			if currentTeam.ScriptsUnavailable {
+				result.Errors = append(result.Errors, "scripts diff skipped: API token lacks permission to read scripts")
+			} else {
+				result.Scripts = diffScripts(currentTeam.Scripts, proposedTeam.Scripts)
+			}
 		}
 
 		if len(changedFiles) > 0 {
@@ -227,6 +234,7 @@ func Diff(current *api.FleetState, proposed *parser.ParsedRepo, teamFilters []st
 			result.Queries = filterResourceDiff(result.Queries, sourceNames, changedFiles)
 			result.Software = filterResourceDiff(result.Software, sourceNames, changedFiles)
 			result.Profiles = filterResourceDiff(result.Profiles, sourceNames, changedFiles)
+			result.Scripts = filterResourceDiff(result.Scripts, sourceNames, changedFiles)
 		}
 
 		result.Labels = validateLabels(proposedTeam, labelMap, changedNames(result.Policies))
@@ -277,6 +285,9 @@ func buildSourceMap(team parser.ParsedTeam) map[string][]string {
 	}
 	for _, p := range team.Profiles {
 		add(p.Name, p.SourceFile)
+	}
+	for _, s := range team.Scripts {
+		add(s.Name, s.SourceFile)
 	}
 	return m
 }
@@ -888,6 +899,36 @@ func diffProfiles(current []api.Profile, proposed []parser.ParsedProfile) (Resou
 	}
 
 	return diff, warnings
+}
+
+// diffScripts compares current scripts (from API) against proposed scripts
+// (from YAML). Scripts are matched by filename.
+func diffScripts(current []api.Script, proposed []parser.ParsedScript) ResourceDiff {
+	var diff ResourceDiff
+
+	currentMap := make(map[string]api.Script)
+	for _, s := range current {
+		currentMap[s.Name] = s
+	}
+
+	proposedNames := make(map[string]bool)
+	for _, s := range proposed {
+		proposedNames[s.Name] = true
+		if _, exists := currentMap[s.Name]; !exists {
+			diff.Added = append(diff.Added, ResourceChange{
+				Name:   s.Name,
+				Fields: map[string]FieldDiff{"path": {New: s.Path}},
+			})
+		}
+	}
+
+	for _, cur := range current {
+		if !proposedNames[cur.Name] {
+			diff.Deleted = append(diff.Deleted, ResourceChange{Name: cur.Name})
+		}
+	}
+
+	return diff
 }
 
 // ---------- Label validation ----------

--- a/internal/diff/differ_test.go
+++ b/internal/diff/differ_test.go
@@ -66,6 +66,10 @@ func TestDiffTestdataAgainstMockAPI(t *testing.T) {
 				Profiles: []api.Profile{
 					{Name: "fleet_orbit-allowfulldiskaccess"},
 				},
+				Scripts: []api.Script{
+					{ID: 1, Name: "enable-desktop.ps1", TeamID: 1},
+					{ID: 2, Name: "old-script.sh", TeamID: 1},
+				},
 			},
 			{
 				ID:   2,
@@ -149,6 +153,21 @@ func TestDiffTestdataAgainstMockAPI(t *testing.T) {
 	if !ws.Profiles.IsEmpty() {
 		t.Errorf("Workstations: expected no profile changes (name matches PayloadDisplayName), got added=%d modified=%d deleted=%d",
 			len(ws.Profiles.Added), len(ws.Profiles.Modified), len(ws.Profiles.Deleted))
+	}
+
+	// Scripts: disk-cleanup.sh is new (added), enable-desktop.ps1 exists (no change), old-script.sh deleted
+	if len(ws.Scripts.Added) != 1 {
+		t.Errorf("Workstations: expected 1 added script, got %d", len(ws.Scripts.Added))
+	} else if ws.Scripts.Added[0].Name != "disk-cleanup.sh" {
+		t.Errorf("Workstations: added script name: got %q", ws.Scripts.Added[0].Name)
+	}
+	if len(ws.Scripts.Deleted) != 1 {
+		t.Errorf("Workstations: expected 1 deleted script, got %d", len(ws.Scripts.Deleted))
+	} else if ws.Scripts.Deleted[0].Name != "old-script.sh" {
+		t.Errorf("Workstations: deleted script name: got %q", ws.Scripts.Deleted[0].Name)
+	}
+	if len(ws.Scripts.Modified) != 0 {
+		t.Errorf("Workstations: expected 0 modified scripts, got %d", len(ws.Scripts.Modified))
 	}
 
 	// Labels: macOS 14+ valid, Ubuntu 24.04 missing
@@ -1571,6 +1590,86 @@ func TestDiffChangedFileFilterYAMLStillWorks(t *testing.T) {
 	r := results[0]
 	if len(r.Software.Modified) != 1 {
 		t.Fatalf("expected 1 modified (YAML match), got %d", len(r.Software.Modified))
+	}
+}
+
+// TestDiffScriptScenarios verifies add, delete, and no-change for scripts.
+func TestDiffScriptScenarios(t *testing.T) {
+	current := &api.FleetState{
+		Teams: []api.Team{{
+			ID:   1,
+			Name: "T",
+			Scripts: []api.Script{
+				{ID: 1, Name: "existing.ps1"},
+				{ID: 2, Name: "to-delete.sh"},
+			},
+		}},
+	}
+
+	proposed := &parser.ParsedRepo{
+		Teams: []parser.ParsedTeam{{
+			Name: "T",
+			Scripts: []parser.ParsedScript{
+				{Name: "existing.ps1", Path: "/repo/scripts/existing.ps1", SourceFile: "/repo/teams/t.yml"},
+				{Name: "new-script.py", Path: "/repo/scripts/new-script.py", SourceFile: "/repo/teams/t.yml"},
+			},
+		}},
+	}
+
+	results := Diff(current, proposed, nil, nil)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+
+	if len(r.Scripts.Added) != 1 {
+		t.Fatalf("expected 1 added script, got %d", len(r.Scripts.Added))
+	}
+	if r.Scripts.Added[0].Name != "new-script.py" {
+		t.Errorf("added script name: got %q", r.Scripts.Added[0].Name)
+	}
+
+	if len(r.Scripts.Deleted) != 1 {
+		t.Fatalf("expected 1 deleted script, got %d", len(r.Scripts.Deleted))
+	}
+	if r.Scripts.Deleted[0].Name != "to-delete.sh" {
+		t.Errorf("deleted script name: got %q", r.Scripts.Deleted[0].Name)
+	}
+
+	if len(r.Scripts.Modified) != 0 {
+		t.Errorf("expected 0 modified scripts, got %d", len(r.Scripts.Modified))
+	}
+}
+
+// TestDiffScriptChangedFileFilter verifies that the changed-file filter
+// includes scripts whose SourceFile matches a changed file.
+func TestDiffScriptChangedFileFilter(t *testing.T) {
+	current := &api.FleetState{
+		Teams: []api.Team{{
+			ID:   1,
+			Name: "T",
+		}},
+	}
+
+	proposed := &parser.ParsedRepo{
+		Teams: []parser.ParsedTeam{{
+			Name: "T",
+			Scripts: []parser.ParsedScript{
+				{Name: "included.ps1", Path: "/repo/scripts/included.ps1", SourceFile: "/repo/teams/t.yml"},
+				{Name: "excluded.sh", Path: "/repo/scripts/excluded.sh", SourceFile: "/repo/teams/other.yml"},
+			},
+		}},
+	}
+
+	results := Diff(current, proposed, nil, []string{"teams/t.yml"})
+	r := results[0]
+
+	// included.ps1 should appear (its SourceFile matches the changed file)
+	if len(r.Scripts.Added) != 1 {
+		t.Fatalf("expected 1 added script (filtered), got %d", len(r.Scripts.Added))
+	}
+	if r.Scripts.Added[0].Name != "included.ps1" {
+		t.Errorf("added script name: got %q, want included.ps1", r.Scripts.Added[0].Name)
 	}
 }
 

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -18,6 +18,7 @@ type JSONTeamDiff struct {
 	Queries  JSONResourceDiff   `json:"queries"`
 	Software JSONResourceDiff   `json:"software"`
 	Profiles JSONResourceDiff   `json:"profiles"`
+	Scripts  JSONResourceDiff   `json:"scripts"`
 	Labels   JSONLabelResult    `json:"labels"`
 	Config   []JSONConfigChange `json:"config,omitempty"`
 	Errors   []string           `json:"errors"`
@@ -78,6 +79,7 @@ func RenderDiffJSON(results []diff.DiffResult) (string, error) {
 			Queries:  convertResourceDiff(r.Queries),
 			Software: convertResourceDiff(r.Software),
 			Profiles: convertResourceDiff(r.Profiles),
+			Scripts:  convertResourceDiff(r.Scripts),
 			Labels:   convertLabels(r.Labels),
 			Config:   convertConfigChanges(r.Config),
 			Errors:   r.Errors,

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -20,6 +20,7 @@ func HasChanges(results []diff.DiffResult) bool {
 	for _, r := range results {
 		if !r.Policies.IsEmpty() || !r.Queries.IsEmpty() ||
 			!r.Software.IsEmpty() || !r.Profiles.IsEmpty() ||
+			!r.Scripts.IsEmpty() ||
 			len(r.Config) > 0 || len(r.Errors) > 0 || len(r.Labels.Missing) > 0 {
 			return true
 		}
@@ -96,6 +97,7 @@ func RenderDiffMarkdown(results []diff.DiffResult, opts MarkdownOptions) string 
 			{"Query", result.Queries},
 			{"Software", result.Software},
 			{"Profile", result.Profiles},
+		{"Script", result.Scripts},
 		}
 
 		for _, rt := range types {

--- a/internal/output/terminal.go
+++ b/internal/output/terminal.go
@@ -102,6 +102,9 @@ func renderTeamDiff(result diff.DiffResult, summary *DiffSummary, verbose bool) 
 	if !result.Profiles.IsEmpty() {
 		lines = append(lines, renderResourceDiff("Profiles", result.Profiles, summary, verbose))
 	}
+	if !result.Scripts.IsEmpty() {
+		lines = append(lines, renderResourceDiff("Scripts", result.Scripts, summary, verbose))
+	}
 
 	for _, e := range result.Errors {
 		display := e

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -103,7 +103,15 @@ type ParsedTeam struct {
 	Queries    []ParsedQuery
 	Software   ParsedSoftware
 	Profiles   []ParsedProfile
+	Scripts    []ParsedScript
 	SourceFile string
+}
+
+// ParsedScript represents a script under controls.scripts.
+type ParsedScript struct {
+	Name       string // filename extracted from path (e.g., "foo.ps1")
+	Path       string // resolved absolute path
+	SourceFile string // team YAML that referenced it
 }
 
 // ParsedPolicy represents a policy from YAML.
@@ -245,7 +253,8 @@ type rawSoftwarePackage struct {
 }
 
 type rawControls struct {
-	MacOSSettings struct {
+	Scripts         []rawPathRef `yaml:"scripts"`
+	MacOSSettings   struct {
 		CustomSettings []rawProfileRef `yaml:"custom_settings"`
 	} `yaml:"macos_settings"`
 	WindowsSettings struct {
@@ -420,6 +429,23 @@ func parseTeamFile(path string) (*ParsedTeam, []ParseError) {
 		team.Software.FleetMaintained = append(team.Software.FleetMaintained, fma)
 	}
 	team.Software.AppStoreApps = raw.Software.AppStoreApps
+
+	// Resolve script paths from controls.scripts[].path.
+	// Fleet identifies scripts by filename, which is what the API returns.
+	for _, ref := range raw.Controls.Scripts {
+		resolved := filepath.Join(dir, ref.Path)
+		if repoRoot != "" {
+			if err := safePath(repoRoot, resolved); err != nil {
+				errs = append(errs, ParseError{File: path, Message: err.Error()})
+				continue
+			}
+		}
+		team.Scripts = append(team.Scripts, ParsedScript{
+			Name:       filepath.Base(resolved),
+			Path:       resolved,
+			SourceFile: path,
+		})
+	}
 
 	// Resolve profile paths and extract names from file content.
 	// Fleet identifies profiles by the name embedded in the file (e.g.,

--- a/testdata/scripts/disk-cleanup.sh
+++ b/testdata/scripts/disk-cleanup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Disk cleanup"

--- a/testdata/scripts/enable-desktop.ps1
+++ b/testdata/scripts/enable-desktop.ps1
@@ -1,0 +1,1 @@
+Write-Host "Enable Fleet Desktop"

--- a/testdata/teams/workstations.yml
+++ b/testdata/teams/workstations.yml
@@ -16,6 +16,9 @@ queries:
   - path: ../queries/shared/uptime.yml
   - path: ../queries/shared/os-version.yml
 controls:
+  scripts:
+    - path: ../scripts/enable-desktop.ps1
+    - path: ../scripts/disk-cleanup.sh
   macos_settings:
     custom_settings:
       - path: ../profiles/mac/renamed-fulldisk.mobileconfig


### PR DESCRIPTION
## Summary

- Add `Script` type, `GetScripts` method, and `ScriptsUnavailable` flag to API client
- Parse `controls.scripts[].path` into `ParsedScript` type with name/path/source tracking
- Add `diffScripts` function matching by filename, with add/delete detection
- Wire scripts into all output renderers (terminal, markdown, JSON) and `HasChanges`
- Add `buildSourceMap` + `filterResourceDiff` support for MR-scoped script filtering

## Test plan

- [x] All existing tests pass
- [x] New `TestDiffScriptScenarios` covers add/delete/no-change
- [x] New `TestDiffScriptChangedFileFilter` covers MR-scoped filtering
- [x] Integration test updated with scripts in mock API state and testdata YAML
- [ ] End-to-end validation via RC release against live Fleet instance

Closes #13