### PR TITLE
fix: Add missing step ID for setup-go in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - id: setup-go
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
## Summary
- The `setup-go` step in `release.yml` had no `id`, so `steps.setup-go.outputs.go-version` resolved to empty
- GoReleaser's ldflags template `{{.Env.GOVERSION}}` failed, producing a release with 0 assets (404 on download)
- Added `id: setup-go` to the step

Ref #32

## Test plan
- [ ] Merge and tag v0.0.12
- [ ] Verify release assets are uploaded and downloadable