### PR TITLE
feat: support modern Fleet GitOps schema (fleets/, apple_settings + windows_settings configuration_profiles, reports:, list-form packages, depth-aware PayloadDisplayName)

### DIFF
--- a/cmd/fleet-plan/main.go
+++ b/cmd/fleet-plan/main.go
@@ -17,10 +17,11 @@ import (
 	"github.com/TsekNet/fleet-plan/internal/api"
 	"github.com/TsekNet/fleet-plan/internal/config"
 	"github.com/TsekNet/fleet-plan/internal/diff"
-	"github.com/TsekNet/fleet-plan/internal/merge"
 	"github.com/TsekNet/fleet-plan/internal/git"
+	"github.com/TsekNet/fleet-plan/internal/merge"
 	"github.com/TsekNet/fleet-plan/internal/output"
 	"github.com/TsekNet/fleet-plan/internal/parser"
+	"github.com/TsekNet/fleet-plan/internal/teamdir"
 )
 
 // Set via -ldflags at build time.
@@ -132,10 +133,11 @@ func runDiff(cmd *cobra.Command, _ []string) error {
 	}
 
 	if len(repo.Teams) == 0 && len(repo.Errors) == 0 {
+		dirName := teamdir.Resolve(flagRepo)
 		if len(teams) > 0 {
-			return fmt.Errorf("no teams matching %v found in %s/teams/", teams, flagRepo)
+			return fmt.Errorf("no teams matching %v found in %s/%s/", teams, flagRepo, dirName)
 		}
-		return fmt.Errorf("no teams found in %s/teams/\nAre you in a fleet-gitops repo? Try --repo /path/to/repo", flagRepo)
+		return fmt.Errorf("no teams found in %s/%s/\nAre you in a fleet-gitops repo? Try --repo /path/to/repo", flagRepo, dirName)
 	}
 
 	// Parse baseline (base branch) for subtraction when in --git mode.

--- a/internal/git/baseline.go
+++ b/internal/git/baseline.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/TsekNet/fleet-plan/internal/teamdir"
 )
 
 // CheckoutBaseline extracts the base-branch versions of the given files into a
@@ -26,8 +28,9 @@ func CheckoutBaseline(repoRoot string, baseRef string, files []string) (tmpRoot 
 	}
 	cleanup = func() { os.RemoveAll(tmpRoot) }
 
-	// Ensure teams/ directory exists so ParseRepo doesn't bail early.
-	os.MkdirAll(filepath.Join(tmpRoot, "teams"), 0o755)
+	// Ensure the team directory exists so ParseRepo doesn't bail early.
+	// Mirror whichever name the source repo uses (fleets/ or teams/).
+	os.MkdirAll(filepath.Join(tmpRoot, teamdir.Resolve(repoRoot)), 0o755)
 
 	// Resolve which files we need: the explicitly changed files, plus any
 	// files they reference (path: directives in team YAML). We start with
@@ -84,7 +87,7 @@ func collectBaselineFiles(repoRoot, baseRef string, changedFiles []string) []str
 	// references. Also extract any referenced resource files so the parser can
 	// resolve them.
 	for _, f := range changedFiles {
-		if !strings.HasPrefix(f, "teams/") && f != "base.yml" && f != "default.yml" {
+		if !teamdir.HasPrefix(f) && f != "base.yml" && f != "default.yml" {
 			continue
 		}
 		content, err := gitShow(repoRoot, baseRef, f)

--- a/internal/git/scope.go
+++ b/internal/git/scope.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/TsekNet/fleet-plan/internal/teamdir"
 	"gopkg.in/yaml.v3"
 )
 
@@ -40,7 +41,7 @@ func ResolveScope(root string, changedFiles []string, envFile string) Scope {
 		case f == "base.yml", f == envFile, strings.HasPrefix(f, "labels/") && !strings.HasSuffix(f, ".md"):
 			scope.IncludeGlobal = true
 
-		case strings.HasPrefix(f, "teams/") && (strings.HasSuffix(f, ".yml") || strings.HasSuffix(f, ".yaml")):
+		case isTeamYAML(f):
 			name := readTeamName(filepath.Join(root, f))
 			if name != "" && !teamsSeen[name] {
 				teamsSeen[name] = true
@@ -80,7 +81,16 @@ func isFleetResource(f string) bool {
 }
 
 func isFleetResourceOrTeam(f string) bool {
-	return isFleetResource(f) || (strings.HasPrefix(f, "teams/") && (strings.HasSuffix(f, ".yml") || strings.HasSuffix(f, ".yaml")))
+	return isFleetResource(f) || isTeamYAML(f)
+}
+
+// isTeamYAML reports whether a repo-relative path is a per-team YAML file
+// under any recognized team directory (fleets/ or teams/).
+func isTeamYAML(f string) bool {
+	if !strings.HasSuffix(f, ".yml") && !strings.HasSuffix(f, ".yaml") {
+		return false
+	}
+	return teamdir.HasPrefix(f)
 }
 
 // buildSearchPatterns returns the set of path strings to grep for in team YAMLs.
@@ -103,12 +113,17 @@ func buildSearchPatterns(root, f string) []string {
 	return patterns
 }
 
-// teamsReferencingAny reads teams/*.yml and returns team names whose file
-// content contains any of the given patterns (plain string search).
+// teamsReferencingAny reads every team YAML in the repo (fleets/ or teams/)
+// and returns team names whose file content contains any of the given patterns
+// (plain string search).
 func teamsReferencingAny(root string, patterns []string) []string {
-	ymlMatches, _ := filepath.Glob(filepath.Join(root, "teams", "*.yml"))
-	yamlMatches, _ := filepath.Glob(filepath.Join(root, "teams", "*.yaml"))
-	matches := append(ymlMatches, yamlMatches...)
+	var matches []string
+	for _, dir := range teamdir.Names() {
+		for _, ext := range []string{"*.yml", "*.yaml"} {
+			m, _ := filepath.Glob(filepath.Join(root, dir, ext))
+			matches = append(matches, m...)
+		}
+	}
 	seen := map[string]bool{}
 	var names []string
 	for _, teamFile := range matches {

--- a/internal/git/scope_test.go
+++ b/internal/git/scope_test.go
@@ -7,10 +7,18 @@ import (
 )
 
 // writeTeamFile creates a team YAML file in root/teams/ with the given name
-// and optional body content referencing resources.
+// and optional body content referencing resources. The legacy teams/ name
+// is kept here so existing test cases continue exercising backwards compat.
 func writeTeamFile(t *testing.T, root, filename, teamName, body string) {
 	t.Helper()
-	dir := filepath.Join(root, "teams")
+	writeTeamFileIn(t, root, "teams", filename, teamName, body)
+}
+
+// writeTeamFileIn is the same as writeTeamFile but lets the caller pick the
+// directory name (used to exercise the canonical fleets/ layout).
+func writeTeamFileIn(t *testing.T, root, dirName, filename, teamName, body string) {
+	t.Helper()
+	dir := filepath.Join(root, dirName)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -130,6 +138,29 @@ func TestResolveScope(t *testing.T) {
 			wantTeams:     []string{"Workstations"},
 			wantTeamCount: 1,
 		},
+		{
+			name: "fleets/ team YAML change resolves team name",
+			setup: func(t *testing.T, root string) {
+				writeTeamFileIn(t, root, "fleets", "infra.yml", "Infrastructure", "")
+			},
+			changedFiles:  []string{"fleets/infra.yml"},
+			wantGlobal:    false,
+			wantTeams:     []string{"Infrastructure"},
+			wantChanged:   []string{"fleets/infra.yml"},
+			wantTeamCount: 1,
+		},
+		{
+			name: "resource change finds referencing fleets/ team",
+			setup: func(t *testing.T, root string) {
+				writeTeamFileIn(t, root, "fleets", "alpha.yml", "Alpha",
+					"controls:\n  scripts:\n    - path: ../scripts/setup.ps1\n")
+			},
+			changedFiles:  []string{"scripts/setup.ps1"},
+			wantGlobal:    false,
+			wantTeams:     []string{"Alpha"},
+			wantChanged:   []string{"scripts/setup.ps1"},
+			wantTeamCount: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -193,6 +224,28 @@ func TestIsFleetResource(t *testing.T) {
 				t.Errorf("isFleetResource(%q) = %v, want %v", tt.path, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestIsTeamYAML(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"fleets/workstations.yml", true},
+		{"teams/workstations.yml", true},
+		{"fleets/infra.yaml", true},
+		{"teams/infra.yaml", true},
+		{"fleets/workstations.md", false},
+		{"policies/disk.yml", false},
+		{"fleets-extra/x.yml", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isTeamYAML(c.path); got != c.want {
+			t.Errorf("isTeamYAML(%q) = %v, want %v", c.path, got, c.want)
+		}
 	}
 }
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/TsekNet/fleet-plan/internal/teamdir"
 	"gopkg.in/yaml.v3"
 )
 
@@ -284,17 +285,18 @@ func MatchesAnyTeam(name string, filters []string) bool {
 func ParseRepo(root string, teamFilters []string, defaultFile string) (*ParsedRepo, error) {
 	repo := &ParsedRepo{}
 
-	teamsDir := filepath.Join(root, "teams")
+	teamsDirName := teamdir.Resolve(root)
+	teamsDir := filepath.Join(root, teamsDirName)
 	entries, err := os.ReadDir(teamsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			repo.Errors = append(repo.Errors, ParseError{
 				File:    teamsDir,
-				Message: "teams/ directory not found. Are you in a fleet-gitops repo?",
+				Message: fmt.Sprintf("%s/ directory not found. Are you in a fleet-gitops repo?", teamsDirName),
 			})
 			return repo, nil
 		}
-		return nil, fmt.Errorf("reading teams directory: %w", err)
+		return nil, fmt.Errorf("reading %s directory: %w", teamsDirName, err)
 	}
 
 	for _, entry := range entries {
@@ -336,7 +338,8 @@ func ParseRepo(root string, teamFilters []string, defaultFile string) (*ParsedRe
 	return repo, nil
 }
 
-// parseTeamFile parses a single teams/*.yml file and resolves all path: refs.
+// parseTeamFile parses a single team YAML file (under fleets/ or teams/) and
+// resolves all path: refs.
 func parseTeamFile(root, path string) (*ParsedTeam, []ParseError) {
 	var errs []ParseError
 
@@ -661,7 +664,7 @@ func extractQueryFromYAML(data []byte) string {
 	return strings.TrimSpace(string(data))
 }
 
-// NormalizeSoftwarePath canonicalizes teams/*.yml software package paths so
+// NormalizeSoftwarePath canonicalizes team YAML software package paths so
 // they match Fleet API's software.packages[].referenced_yaml_path format.
 // Example: "../software/mac/slack/slack.yml" -> "software/mac/slack/slack.yml"
 func NormalizeSoftwarePath(p string) string {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -888,33 +888,73 @@ func extractProfileName(filePath string) string {
 // PayloadDisplayName) and a top-level PayloadDisplayName. Fleet uses the
 // top-level one as the profile identity.
 //
-// In standard plist layout, the top-level PayloadDisplayName appears AFTER
-// the PayloadContent array, so it's the last occurrence in the file.
+// The order of PayloadDisplayName relative to PayloadContent is not
+// standardized — Apple Configurator emits it before the array, ProfileCreator
+// after, hand-edited files vary. So we can't rely on first/last position;
+// instead we track <dict> nesting depth and only accept PayloadDisplayName
+// at depth 1 (direct child of the root dict; depth 0 is <plist>).
 func extractMobileconfigName(data []byte) string {
 	s := string(data)
-	needle := "<key>PayloadDisplayName</key>"
-	last := ""
+	const needle = "<key>PayloadDisplayName</key>"
 
-	// Find all occurrences and keep the last one — that's the top-level dict entry.
-	remaining := s
+	depth := 0 // <dict> nesting depth, starting at 0 (outside <plist>'s root <dict>).
+	// dictOpen reports whether a <dict> tag at position i is an opening tag
+	// (not self-closing).
+	scanTags := func(seg string) {
+		i := 0
+		for i < len(seg) {
+			lt := strings.IndexByte(seg[i:], '<')
+			if lt < 0 {
+				return
+			}
+			i += lt
+			if strings.HasPrefix(seg[i:], "<dict>") {
+				depth++
+				i += len("<dict>")
+				continue
+			}
+			if strings.HasPrefix(seg[i:], "<dict/>") {
+				// Self-closing — no children; depth unchanged.
+				i += len("<dict/>")
+				continue
+			}
+			if strings.HasPrefix(seg[i:], "</dict>") {
+				depth--
+				i += len("</dict>")
+				continue
+			}
+			// Skip past this tag.
+			gt := strings.IndexByte(seg[i:], '>')
+			if gt < 0 {
+				return
+			}
+			i += gt + 1
+		}
+	}
+
+	cursor := 0
 	for {
-		idx := strings.Index(remaining, needle)
+		idx := strings.Index(s[cursor:], needle)
 		if idx < 0 {
 			break
 		}
-		after := remaining[idx+len(needle):]
-		after = strings.TrimSpace(after)
-		if strings.HasPrefix(after, "<string>") {
-			after = after[len("<string>"):]
-			end := strings.Index(after, "</string>")
-			if end >= 0 {
-				last = strings.TrimSpace(after[:end])
+		absIdx := cursor + idx
+		// Update depth based on every <dict>/</dict> between cursor and this match.
+		scanTags(s[cursor:absIdx])
+		// Skip past the <key>PayloadDisplayName</key> tag itself.
+		cursor = absIdx + len(needle)
+		// At depth 1, this is the top-level dict's PayloadDisplayName.
+		if depth == 1 {
+			after := strings.TrimSpace(s[cursor:])
+			if strings.HasPrefix(after, "<string>") {
+				after = after[len("<string>"):]
+				if end := strings.Index(after, "</string>"); end >= 0 {
+					return strings.TrimSpace(after[:end])
+				}
 			}
 		}
-		remaining = remaining[idx+len(needle):]
 	}
-
-	return last
+	return ""
 }
 
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -65,6 +65,13 @@ var ValidTopLevelKeys = map[string]bool{
 	"queries":       true,
 	"software":      true,
 	"labels":        true,
+	// Newer Fleet schema additions accepted by `fleetctl gitops`. We parse
+	// these as opaque maps so they don't break validation; field-level diffing
+	// of these sections isn't implemented yet but the absence of an error
+	// keeps the rest of the diff (profiles, policies, queries, software)
+	// trustworthy.
+	"settings":      true,
+	"reports":       true,
 }
 
 // Valid label membership types (from server/fleet/labels.go).
@@ -252,17 +259,28 @@ type rawSoftwarePackage struct {
 }
 
 type rawControls struct {
-	Scripts         []rawPathRef `yaml:"scripts"`
-	MacOSSettings   struct {
+	Scripts       []rawPathRef `yaml:"scripts"`
+	MacOSSettings struct {
 		CustomSettings []rawProfileRef `yaml:"custom_settings"`
 	} `yaml:"macos_settings"`
 	WindowsSettings struct {
 		CustomSettings []rawProfileRef `yaml:"custom_settings"`
 	} `yaml:"windows_settings"`
+	// AppleSettings is the modern unified Apple-platform block, replacing
+	// macos_settings.custom_settings. configuration_profiles entries can be
+	// .mobileconfig (macOS/iOS/iPadOS), .json (DDM declarations), or .xml.
+	// The platform is inferred from the file path (e.g. lib/ipados/...) and
+	// from file extension if no path hint is present.
+	AppleSettings struct {
+		ConfigurationProfiles []rawProfileRef `yaml:"configuration_profiles"`
+	} `yaml:"apple_settings"`
 }
 
 type rawProfileRef struct {
-	Path string `yaml:"path"`
+	Path             string   `yaml:"path"`
+	LabelsIncludeAny []string `yaml:"labels_include_any"`
+	LabelsExcludeAny []string `yaml:"labels_exclude_any"`
+	LabelsIncludeAll []string `yaml:"labels_include_all"`
 }
 
 // ---------- Parser ----------
@@ -496,7 +514,47 @@ func parseTeamFile(root, path string) (*ParsedTeam, []ParseError) {
 		})
 	}
 
+	// apple_settings.configuration_profiles is the unified modern block that
+	// supersedes macos_settings.custom_settings. Entries may be .mobileconfig
+	// (macOS/iOS/iPadOS), .json (DDM declarations), or .xml. Diff identity is
+	// by name (PayloadDisplayName or filename for DDM); platform is informational.
+	for _, ref := range raw.Controls.AppleSettings.ConfigurationProfiles {
+		resolved := filepath.Join(dir, ref.Path)
+		if root != "" {
+			if err := safePath(root, resolved); err != nil {
+				errs = append(errs, ParseError{File: path, Message: err.Error()})
+				continue
+			}
+		}
+		name := extractProfileName(resolved)
+		if name == "" {
+			name = profileNameFromFilename(resolved)
+		}
+		team.Profiles = append(team.Profiles, ParsedProfile{
+			Path:       resolved,
+			Name:       name,
+			Platform:   inferApplePlatform(ref.Path),
+			SourceFile: path,
+		})
+	}
+
 	return team, errs
+}
+
+// inferApplePlatform returns a coarse platform string based on the path
+// segment. lib/ipados/* → ipados, lib/ios/* → ios, anything else → darwin
+// (covers lib/macos/, lib/all/, lib/unassigned/, etc.). Fleet's diff identity
+// is the embedded profile name, not platform — this is purely for display.
+func inferApplePlatform(refPath string) string {
+	clean := strings.ToLower(filepath.ToSlash(filepath.Clean(refPath)))
+	switch {
+	case strings.Contains(clean, "/ipados/"):
+		return "ipados"
+	case strings.Contains(clean, "/ios/"):
+		return "ios"
+	default:
+		return "darwin"
+	}
 }
 
 // readYAMLRef resolves a path: reference, validates it stays within the repo

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -65,11 +65,11 @@ var ValidTopLevelKeys = map[string]bool{
 	"queries":       true,
 	"software":      true,
 	"labels":        true,
-	// Newer Fleet schema additions accepted by `fleetctl gitops`. We parse
-	// these as opaque maps so they don't break validation; field-level diffing
-	// of these sections isn't implemented yet but the absence of an error
-	// keeps the rest of the diff (profiles, policies, queries, software)
-	// trustworthy.
+	// Newer Fleet schema additions accepted by `fleetctl gitops`.
+	// `reports:` is the renamed `queries:` (fleetdm/fleet#40726); we parse
+	// it fully via rawTeamFile.Reports. `settings:` is currently accepted
+	// as opaque — field-level diffing isn't implemented but the absence of
+	// an error keeps the rest of the diff trustworthy.
 	"settings":      true,
 	"reports":       true,
 }
@@ -219,8 +219,13 @@ type rawTeamFile struct {
 	Controls     rawControls      `yaml:"controls"`
 	Policies     []rawPathRef     `yaml:"policies"`
 	Queries      []rawPathRef     `yaml:"queries"`
-	Software     rawSoftwareBlock `yaml:"software"`
-	Labels       []rawPathRef     `yaml:"labels"`
+	// Reports is the renamed-in-fleetdm/fleet#40726 spelling of queries.
+	// `fleetctl gitops` accepts both; we treat them as equivalent here so
+	// repos that use the modern `reports:` keyword don't show every live
+	// Fleet query as REMOVED on the diff.
+	Reports  []rawPathRef     `yaml:"reports"`
+	Software rawSoftwareBlock `yaml:"software"`
+	Labels   []rawPathRef     `yaml:"labels"`
 }
 
 type rawPathRef struct {
@@ -402,8 +407,10 @@ func parseTeamFile(root, path string) (*ParsedTeam, []ParseError) {
 		team.Policies = append(team.Policies, policies...)
 	}
 
-	// Resolve queries
-	for _, ref := range raw.Queries {
+	// Resolve queries. Both `queries:` and `reports:` are accepted — Fleet
+	// renamed the key in fleetdm/fleet#40726 but kept the old spelling
+	// working, so repos may use either or both during transition.
+	for _, ref := range append(append([]rawPathRef(nil), raw.Queries...), raw.Reports...) {
 		queries, parseErrs := resolveQueryRef(root, dir, ref.Path, path)
 		errs = append(errs, parseErrs...)
 		team.Queries = append(team.Queries, queries...)
@@ -760,11 +767,13 @@ func parseDefaultFile(root, path string) (*parsedDefault, []ParseError) {
 		return nil, []ParseError{{File: path, Message: fmt.Sprintf("YAML parse error: %s", err)}}
 	}
 
-	// Parse structured fields (labels, policies, queries path refs)
+	// Parse structured fields (labels, policies, queries path refs).
+	// `reports:` is the renamed-in-#40726 alias for `queries:`.
 	var rawStruct struct {
 		Labels   []rawPathRef `yaml:"labels"`
 		Policies []rawPathRef `yaml:"policies"`
 		Queries  []rawPathRef `yaml:"queries"`
+		Reports  []rawPathRef `yaml:"reports"`
 	}
 	if err := yaml.Unmarshal(data, &rawStruct); err != nil {
 		return nil, []ParseError{{File: path, Message: fmt.Sprintf("YAML parse error: %s", err)}}
@@ -798,8 +807,9 @@ func parseDefaultFile(root, path string) (*parsedDefault, []ParseError) {
 		global.Policies = append(global.Policies, policies...)
 	}
 
-	// Resolve global queries
-	for _, ref := range rawStruct.Queries {
+	// Resolve global queries. Accept both `queries:` and the renamed
+	// `reports:` (fleetdm/fleet#40726); see rawTeamFile for context.
+	for _, ref := range append(append([]rawPathRef(nil), rawStruct.Queries...), rawStruct.Reports...) {
 		queries, parseErrs := resolveQueryRef(root, dir, ref.Path, path)
 		errs = append(errs, parseErrs...)
 		global.Queries = append(global.Queries, queries...)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -70,8 +70,8 @@ var ValidTopLevelKeys = map[string]bool{
 	// it fully via rawTeamFile.Reports. `settings:` is currently accepted
 	// as opaque — field-level diffing isn't implemented but the absence of
 	// an error keeps the rest of the diff trustworthy.
-	"settings":      true,
-	"reports":       true,
+	"settings": true,
+	"reports":  true,
 }
 
 // Valid label membership types (from server/fleet/labels.go).
@@ -212,13 +212,13 @@ func (e ParseError) Error() string {
 // ---------- Team YAML raw types (for initial parsing) ----------
 
 type rawTeamFile struct {
-	Name         string           `yaml:"name"`
-	TeamSettings yaml.Node        `yaml:"team_settings"`
-	OrgSettings  yaml.Node        `yaml:"org_settings"`
-	AgentOptions yaml.Node        `yaml:"agent_options"`
-	Controls     rawControls      `yaml:"controls"`
-	Policies     []rawPathRef     `yaml:"policies"`
-	Queries      []rawPathRef     `yaml:"queries"`
+	Name         string       `yaml:"name"`
+	TeamSettings yaml.Node    `yaml:"team_settings"`
+	OrgSettings  yaml.Node    `yaml:"org_settings"`
+	AgentOptions yaml.Node    `yaml:"agent_options"`
+	Controls     rawControls  `yaml:"controls"`
+	Policies     []rawPathRef `yaml:"policies"`
+	Queries      []rawPathRef `yaml:"queries"`
 	// Reports is the renamed-in-fleetdm/fleet#40726 spelling of queries.
 	// `fleetctl gitops` accepts both; we treat them as equivalent here so
 	// repos that use the modern `reports:` keyword don't show every live
@@ -239,12 +239,12 @@ type rawSoftwareBlock struct {
 }
 
 type rawFleetApp struct {
-	Slug              string       `yaml:"slug"`
-	SelfService       bool         `yaml:"self_service"`
-	InstallScript     *rawPathRef  `yaml:"install_script"`
-	UninstallScript   *rawPathRef  `yaml:"uninstall_script"`
-	PreInstallQuery   *rawPathRef  `yaml:"pre_install_query"`
-	PostInstallScript *rawPathRef  `yaml:"post_install_script"`
+	Slug              string      `yaml:"slug"`
+	SelfService       bool        `yaml:"self_service"`
+	InstallScript     *rawPathRef `yaml:"install_script"`
+	UninstallScript   *rawPathRef `yaml:"uninstall_script"`
+	PreInstallQuery   *rawPathRef `yaml:"pre_install_query"`
+	PostInstallScript *rawPathRef `yaml:"post_install_script"`
 }
 
 type rawSoftwareRef struct {
@@ -270,6 +270,12 @@ type rawControls struct {
 	} `yaml:"macos_settings"`
 	WindowsSettings struct {
 		CustomSettings []rawProfileRef `yaml:"custom_settings"`
+		// ConfigurationProfiles is the modern key (mirroring
+		// apple_settings.configuration_profiles) that fleetctl gitops accepts
+		// for Windows profiles. Both spellings are valid; profiles defined here
+		// must be parsed or every matching live Fleet profile is reported as
+		// REMOVED.
+		ConfigurationProfiles []rawProfileRef `yaml:"configuration_profiles"`
 	} `yaml:"windows_settings"`
 	// AppleSettings is the modern unified Apple-platform block, replacing
 	// macos_settings.custom_settings. configuration_profiles entries can be
@@ -501,7 +507,13 @@ func parseTeamFile(root, path string) (*ParsedTeam, []ParseError) {
 			SourceFile: path,
 		})
 	}
-	for _, ref := range raw.Controls.WindowsSettings.CustomSettings {
+	// Windows profiles may be listed under custom_settings (older spelling) or
+	// configuration_profiles (modern spelling, mirroring apple_settings).
+	// fleetctl gitops accepts both, so parse both.
+	for _, ref := range append(
+		append([]rawProfileRef(nil), raw.Controls.WindowsSettings.CustomSettings...),
+		raw.Controls.WindowsSettings.ConfigurationProfiles...,
+	) {
 		resolved := filepath.Join(dir, ref.Path)
 		if root != "" {
 			if err := safePath(root, resolved); err != nil {
@@ -642,9 +654,19 @@ func resolveSoftwareRef(root, baseDir, refPath, parentFile string) ([]ParsedSoft
 		return nil, errs
 	}
 
+	// A package file may be a single object (url: ...) or a single-element
+	// list (- url: ...). fleetctl gitops accepts both, so fall back to the
+	// list form when object unmarshaling fails (mirrors resolvePolicyRef /
+	// resolveQueryRef). Without this the list form is dropped and the package
+	// is falsely reported as REMOVED.
 	var raw rawSoftwarePackage
 	if err := yaml.Unmarshal(data, &raw); err != nil {
-		return nil, []ParseError{{File: resolved, Message: fmt.Sprintf("YAML parse error: %s", err)}}
+		var list []rawSoftwarePackage
+		if err2 := yaml.Unmarshal(data, &list); err2 == nil && len(list) > 0 {
+			raw = list[0]
+		} else {
+			return nil, []ParseError{{File: resolved, Message: fmt.Sprintf("YAML parse error: %s", err)}}
+		}
 	}
 
 	pkg := ParsedSoftwarePackage{
@@ -966,7 +988,6 @@ func extractMobileconfigName(data []byte) string {
 	}
 	return ""
 }
-
 
 // profileNameFromFilename derives a profile name from the filename by stripping
 // the extension. This is the fallback when content extraction fails.

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -260,8 +260,10 @@ func TestExtractProfileNameFallback(t *testing.T) {
 }
 
 // TestExtractMobileconfigName verifies PayloadDisplayName extraction from plist XML.
-// Fleet uses the top-level PayloadDisplayName (the last occurrence in the file)
-// as the profile identity, not the nested ones inside PayloadContent.
+// Fleet uses the top-level PayloadDisplayName (the one at the root dict, depth 1)
+// as the profile identity, not the nested ones inside PayloadContent. Position
+// within the file is not meaningful — different profile generators emit the
+// top-level PayloadDisplayName before or after PayloadContent.
 func TestExtractMobileconfigName(t *testing.T) {
 	// Top-level PayloadDisplayName after PayloadContent array — should return
 	// the top-level one (last occurrence), not the inner one.
@@ -321,6 +323,33 @@ func TestExtractMobileconfigName(t *testing.T) {
 	name = extractMobileconfigName([]byte(simple))
 	if name != "Simple Profile" {
 		t.Errorf("expected %q, got %q", "Simple Profile", name)
+	}
+
+	// Top-level PayloadDisplayName BEFORE PayloadContent — the order Apple
+	// Configurator emits and what most hand-edited profiles look like.
+	// Earlier extractor used the last occurrence and would have returned
+	// the deepest nested name; now we require depth=1.
+	topFirst := `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>PayloadDisplayName</key>
+	<string>Zoom Room Activation Code — University of Pennsylvania (Room2)</string>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>Zoom Room Activation Code</string>
+		</dict>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>Zoom Room Activation Code (Mac)</string>
+		</dict>
+	</array>
+</dict>
+</plist>`
+	name = extractMobileconfigName([]byte(topFirst))
+	if name != "Zoom Room Activation Code — University of Pennsylvania (Room2)" {
+		t.Errorf("top-first ordering: expected the outer PayloadDisplayName, got %q", name)
 	}
 
 	// No PayloadDisplayName at all

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -785,9 +785,9 @@ team_settings: {}
 		got[p.Name] = p.Platform
 	}
 	want := map[string]string{
-		"Mac Energy Saver":     "darwin",
-		"ipad-force-os":        "ipados",
-		"ios-restrictions":     "ios",
+		"Mac Energy Saver": "darwin",
+		"ipad-force-os":    "ipados",
+		"ios-restrictions": "ios",
 	}
 	for name, plat := range want {
 		if got[name] != plat {
@@ -867,5 +867,119 @@ reports:
 	}
 	if len(repo.Teams[0].Queries) != 1 || repo.Teams[0].Queries[0].Name != "My Report Query" {
 		t.Errorf("expected 1 query named %q from reports:, got %+v", "My Report Query", repo.Teams[0].Queries)
+	}
+}
+
+// TestParseRepoWindowsConfigurationProfiles verifies that
+// controls.windows_settings.configuration_profiles is parsed. This is the
+// modern key (mirroring apple_settings.configuration_profiles) that fleetctl
+// gitops accepts alongside the older windows_settings.custom_settings. Without
+// it, Windows profiles defined under configuration_profiles never appear on the
+// proposed side and every matching live Fleet profile is reported as REMOVED.
+func TestParseRepoWindowsConfigurationProfiles(t *testing.T) {
+	root := t.TempDir()
+	fleetsDir := filepath.Join(root, "fleets")
+	winDir := filepath.Join(root, "lib", "windows", "configuration-profiles")
+	for _, d := range []string{fleetsDir, winDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Windows .xml profile — Fleet identifies it by filename, not content.
+	if err := os.WriteFile(filepath.Join(winDir, "campus-wifi-8021x.xml"), []byte(`<Replace></Replace>`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Label-scoped entry to mirror the real-world pilot config.
+	teamYAML := `name: T1
+team_settings: {}
+controls:
+  windows_settings:
+    configuration_profiles:
+      - path: ../lib/windows/configuration-profiles/campus-wifi-8021x.xml
+        labels_include_any:
+          - test-pilots
+`
+	if err := os.WriteFile(filepath.Join(fleetsDir, "t1.yml"), []byte(teamYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	repo, err := ParseRepo(root, nil, "")
+	if err != nil {
+		t.Fatalf("ParseRepo: %v", err)
+	}
+	if len(repo.Errors) != 0 {
+		t.Fatalf("unexpected errors: %v", repo.Errors)
+	}
+	if len(repo.Teams) != 1 {
+		t.Fatalf("expected 1 team, got %d", len(repo.Teams))
+	}
+	var got []string
+	for _, p := range repo.Teams[0].Profiles {
+		got = append(got, p.Name+"|"+p.Platform)
+	}
+	want := "campus-wifi-8021x|windows"
+	found := false
+	for _, g := range got {
+		if g == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("windows_settings.configuration_profiles not parsed: want %q in %v", want, got)
+	}
+}
+
+// TestParseSoftwarePackageListForm verifies that a package YAML file written as
+// a single-element list (- url: ...) parses identically to the single-object
+// form (url: ...). fleetctl gitops accepts both, but resolveSoftwareRef
+// originally only unmarshaled the object form; the list form failed to parse,
+// dropping the package from the proposed side and reporting it as REMOVED.
+func TestParseSoftwarePackageListForm(t *testing.T) {
+	root := t.TempDir()
+	teamsDir := filepath.Join(root, "teams")
+	softwareDir := filepath.Join(root, "software", "windows", "list-app")
+	if err := os.MkdirAll(teamsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(softwareDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// List form: a one-element YAML sequence rather than a top-level map.
+	pkgYAML := `- url: https://downloads.example.com/list-app.exe
+  display_name: List App
+  self_service: true
+`
+	if err := os.WriteFile(filepath.Join(softwareDir, "list-app.yml"), []byte(pkgYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	teamYAML := `name: Workstations
+team_settings: {}
+software:
+  packages:
+    - path: ../software/windows/list-app/list-app.yml
+      labels_include_any:
+        - test-pilots
+`
+	if err := os.WriteFile(filepath.Join(teamsDir, "workstations.yml"), []byte(teamYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	repo, err := ParseRepo(root, nil, "")
+	if err != nil {
+		t.Fatalf("ParseRepo: %v", err)
+	}
+	if len(repo.Errors) != 0 {
+		t.Fatalf("unexpected errors: %v", repo.Errors)
+	}
+	if len(repo.Teams) != 1 {
+		t.Fatalf("expected 1 team, got %d", len(repo.Teams))
+	}
+	pkgs := repo.Teams[0].Software.Packages
+	if len(pkgs) != 1 {
+		t.Fatalf("expected 1 package from list-form file, got %d: %+v", len(pkgs), pkgs)
+	}
+	if pkgs[0].URL != "https://downloads.example.com/list-app.exe" {
+		t.Errorf("package URL = %q, want list-app.exe URL", pkgs[0].URL)
+	}
+	if !pkgs[0].SelfService {
+		t.Errorf("self_service from list-form package not parsed (want true)")
 	}
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -796,10 +796,10 @@ team_settings: {}
 	}
 }
 
-// TestParseRepoAcceptsSettingsAndReportsKeys covers top-level `settings:` and
-// `reports:` keys that current Fleet GitOps yaml includes but fleet-plan
-// originally rejected as unknown.
-func TestParseRepoAcceptsSettingsAndReportsKeys(t *testing.T) {
+// TestParseRepoAcceptsSettingsKey covers the top-level `settings:` block,
+// which current Fleet GitOps yaml includes but fleet-plan originally
+// rejected as unknown. It is parsed opaquely (no field-level diff yet).
+func TestParseRepoAcceptsSettingsKey(t *testing.T) {
 	root := t.TempDir()
 	fleetsDir := filepath.Join(root, "fleets")
 	if err := os.MkdirAll(fleetsDir, 0o755); err != nil {
@@ -810,8 +810,6 @@ team_settings: {}
 settings:
   host_expiry_settings:
     host_expiry_enabled: false
-reports:
-  - name: example
 `
 	if err := os.WriteFile(filepath.Join(fleetsDir, "t1.yml"), []byte(teamYAML), 0o644); err != nil {
 		t.Fatal(err)
@@ -824,5 +822,50 @@ reports:
 		if strings.Contains(e.Message, "unknown top-level key") {
 			t.Errorf("unexpected unknown-key error: %v", e)
 		}
+	}
+}
+
+// TestParseRepoReportsAliasesQueries verifies that `reports:` (the renamed
+// `queries:` from fleetdm/fleet#40726) is parsed as path refs and merged
+// into the team's query list. Without this, queries defined under `reports:`
+// don't appear on the proposed side and Fleet's live queries get reported
+// as REMOVED.
+func TestParseRepoReportsAliasesQueries(t *testing.T) {
+	root := t.TempDir()
+	fleetsDir := filepath.Join(root, "fleets")
+	queriesDir := filepath.Join(root, "lib", "queries")
+	for _, d := range []string{fleetsDir, queriesDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A query file in the standard Fleet GitOps list-of-queries format.
+	queryYAML := `- name: My Report Query
+  query: SELECT 1;
+  platform: darwin
+`
+	if err := os.WriteFile(filepath.Join(queriesDir, "rpt.yml"), []byte(queryYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	teamYAML := `name: T1
+team_settings: {}
+reports:
+  - path: ../lib/queries/rpt.yml
+`
+	if err := os.WriteFile(filepath.Join(fleetsDir, "t1.yml"), []byte(teamYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	repo, err := ParseRepo(root, nil, "")
+	if err != nil {
+		t.Fatalf("ParseRepo: %v", err)
+	}
+	if len(repo.Errors) != 0 {
+		t.Fatalf("unexpected errors: %v", repo.Errors)
+	}
+	if len(repo.Teams) != 1 {
+		t.Fatalf("expected 1 team, got %d", len(repo.Teams))
+	}
+	if len(repo.Teams[0].Queries) != 1 || repo.Teams[0].Queries[0].Name != "My Report Query" {
+		t.Errorf("expected 1 query named %q from reports:, got %+v", "My Report Query", repo.Teams[0].Queries)
 	}
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -420,8 +420,8 @@ team_settings: {}
 		},
 		{
 			name:       "missing teams directory",
-			wantErrMsg: "teams",
-			setup:      func(root string) {}, // empty dir, no teams/
+			wantErrMsg: "directory not found",
+			setup:      func(root string) {}, // empty dir, no fleets/ or teams/
 		},
 		{
 			name:       "missing name field",
@@ -624,5 +624,65 @@ team_settings: {}
 	}
 	if !foundDupErr {
 		t.Fatalf("expected duplicate software package error, got: %+v", repo.Errors)
+	}
+}
+
+// TestParseRepoFleetsDir verifies the new canonical directory name (fleets/)
+// produced by Fleet's `fleetctl new` since the teams->fleets migration.
+func TestParseRepoFleetsDir(t *testing.T) {
+	root := t.TempDir()
+	fleetsDir := filepath.Join(root, "fleets")
+	if err := os.MkdirAll(fleetsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	teamYAML := `name: Workstations
+policies: []
+queries: []
+software:
+  packages: []
+team_settings: {}
+`
+	if err := os.WriteFile(filepath.Join(fleetsDir, "workstations.yml"), []byte(teamYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	repo, err := ParseRepo(root, nil, "")
+	if err != nil {
+		t.Fatalf("ParseRepo: %v", err)
+	}
+	if len(repo.Teams) != 1 {
+		t.Fatalf("expected 1 team from fleets/, got %d (errors: %v)", len(repo.Teams), repo.Errors)
+	}
+	if repo.Teams[0].Name != "Workstations" {
+		t.Errorf("team name = %q, want %q", repo.Teams[0].Name, "Workstations")
+	}
+}
+
+// TestParseRepoFleetsTakesPriorityOverTeams verifies fleets/ wins when both
+// directories exist (defensive behavior for repos mid-migration).
+func TestParseRepoFleetsTakesPriorityOverTeams(t *testing.T) {
+	root := t.TempDir()
+	fleetsDir := filepath.Join(root, "fleets")
+	teamsDir := filepath.Join(root, "teams")
+	if err := os.MkdirAll(fleetsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(teamsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(dir, name, body string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(fleetsDir, "ws.yml", "name: FromFleets\npolicies: []\nqueries: []\nsoftware:\n  packages: []\nteam_settings: {}\n")
+	write(teamsDir, "ws.yml", "name: FromTeams\npolicies: []\nqueries: []\nsoftware:\n  packages: []\nteam_settings: {}\n")
+
+	repo, err := ParseRepo(root, nil, "")
+	if err != nil {
+		t.Fatalf("ParseRepo: %v", err)
+	}
+	if len(repo.Teams) != 1 || repo.Teams[0].Name != "FromFleets" {
+		t.Fatalf("expected single team named FromFleets, got %d teams: %+v", len(repo.Teams), repo.Teams)
 	}
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -686,3 +686,114 @@ func TestParseRepoFleetsTakesPriorityOverTeams(t *testing.T) {
 		t.Fatalf("expected single team named FromFleets, got %d teams: %+v", len(repo.Teams), repo.Teams)
 	}
 }
+
+// TestParseRepoAppleSettings exercises controls.apple_settings.configuration_profiles,
+// the modern unified block that replaced macos_settings.custom_settings. Each
+// referenced file should produce a ParsedProfile with platform inferred from
+// the path (macos/ → darwin, ipados/ → ipados, ios/ → ios).
+func TestParseRepoAppleSettings(t *testing.T) {
+	root := t.TempDir()
+	fleetsDir := filepath.Join(root, "fleets")
+	macosDir := filepath.Join(root, "lib", "macos", "profiles")
+	ipadosDir := filepath.Join(root, "lib", "ipados", "profiles")
+	iosDir := filepath.Join(root, "lib", "ios", "profiles")
+	for _, d := range []string{fleetsDir, macosDir, ipadosDir, iosDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// .mobileconfig with a PayloadDisplayName so extractProfileName succeeds.
+	mobileconfig := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadDisplayName</key>
+  <string>Mac Energy Saver</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+</dict>
+</plist>
+`
+	if err := os.WriteFile(filepath.Join(macosDir, "energy.mobileconfig"), []byte(mobileconfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// DDM .json — name comes from filename.
+	if err := os.WriteFile(filepath.Join(ipadosDir, "ipad-force-os.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(iosDir, "ios-restrictions.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	teamYAML := `name: Mixed Apple
+controls:
+  apple_settings:
+    configuration_profiles:
+      - path: ../lib/macos/profiles/energy.mobileconfig
+        labels_include_any: [mac-fleet]
+      - path: ../lib/ipados/profiles/ipad-force-os.json
+        labels_include_any: [ipad-fleet]
+      - path: ../lib/ios/profiles/ios-restrictions.json
+team_settings: {}
+`
+	if err := os.WriteFile(filepath.Join(fleetsDir, "mixed.yml"), []byte(teamYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	repo, err := ParseRepo(root, nil, "")
+	if err != nil {
+		t.Fatalf("ParseRepo: %v", err)
+	}
+	if len(repo.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", repo.Errors)
+	}
+	if len(repo.Teams) != 1 {
+		t.Fatalf("expected 1 team, got %d", len(repo.Teams))
+	}
+	got := map[string]string{}
+	for _, p := range repo.Teams[0].Profiles {
+		got[p.Name] = p.Platform
+	}
+	want := map[string]string{
+		"Mac Energy Saver":     "darwin",
+		"ipad-force-os":        "ipados",
+		"ios-restrictions":     "ios",
+	}
+	for name, plat := range want {
+		if got[name] != plat {
+			t.Errorf("profile %q: platform = %q, want %q (full map: %v)", name, got[name], plat, got)
+		}
+	}
+}
+
+// TestParseRepoAcceptsSettingsAndReportsKeys covers top-level `settings:` and
+// `reports:` keys that current Fleet GitOps yaml includes but fleet-plan
+// originally rejected as unknown.
+func TestParseRepoAcceptsSettingsAndReportsKeys(t *testing.T) {
+	root := t.TempDir()
+	fleetsDir := filepath.Join(root, "fleets")
+	if err := os.MkdirAll(fleetsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	teamYAML := `name: T1
+team_settings: {}
+settings:
+  host_expiry_settings:
+    host_expiry_enabled: false
+reports:
+  - name: example
+`
+	if err := os.WriteFile(filepath.Join(fleetsDir, "t1.yml"), []byte(teamYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	repo, err := ParseRepo(root, nil, "")
+	if err != nil {
+		t.Fatalf("ParseRepo: %v", err)
+	}
+	for _, e := range repo.Errors {
+		if strings.Contains(e.Message, "unknown top-level key") {
+			t.Errorf("unexpected unknown-key error: %v", e)
+		}
+	}
+}

--- a/internal/teamdir/teamdir.go
+++ b/internal/teamdir/teamdir.go
@@ -1,0 +1,49 @@
+// Package teamdir resolves the directory name that holds per-team YAML files
+// inside a fleet-gitops repository.
+//
+// Fleet originally called these "teams" and stored them in teams/. Starting
+// with Fleet PR #40726, the canonical name is "fleets" stored in fleets/.
+// Both layouts remain valid: this package prefers fleets/, falls back to
+// teams/, and reports which one a given repo uses.
+package teamdir
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Preferred is the name used when neither directory exists yet (e.g. when
+// preparing a baseline scratch dir) or when both exist.
+const Preferred = "fleets"
+
+// Legacy is the older directory name still accepted for backwards compatibility.
+const Legacy = "teams"
+
+// Names returns the candidate directory names in priority order. Useful for
+// callers that need to scan both layouts (e.g. git scope detection where the
+// changed-file path's prefix is what's known, not the on-disk directory).
+func Names() []string { return []string{Preferred, Legacy} }
+
+// Resolve returns the name of the team directory inside root, preferring
+// fleets/ over teams/. If neither exists, Preferred is returned so callers
+// have a sensible default for error messages and scratch-dir creation.
+func Resolve(root string) string {
+	for _, name := range Names() {
+		if info, err := os.Stat(filepath.Join(root, name)); err == nil && info.IsDir() {
+			return name
+		}
+	}
+	return Preferred
+}
+
+// HasPrefix reports whether the given repo-relative path lives under any
+// recognized team directory (fleets/ or teams/).
+func HasPrefix(path string) bool {
+	for _, name := range Names() {
+		if strings.HasPrefix(path, name+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/teamdir/teamdir_test.go
+++ b/internal/teamdir/teamdir_test.go
@@ -1,0 +1,60 @@
+package teamdir
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolvePrefersFleets(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "fleets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "teams"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := Resolve(root); got != "fleets" {
+		t.Errorf("Resolve = %q, want %q", got, "fleets")
+	}
+}
+
+func TestResolveFallsBackToTeams(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "teams"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := Resolve(root); got != "teams" {
+		t.Errorf("Resolve = %q, want %q", got, "teams")
+	}
+}
+
+func TestResolveDefaultsToFleets(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if got := Resolve(root); got != "fleets" {
+		t.Errorf("Resolve = %q, want %q (default)", got, "fleets")
+	}
+}
+
+func TestHasPrefix(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"fleets/workstations.yml", true},
+		{"teams/workstations.yml", true},
+		{"fleetstuff/x.yml", false},
+		{"policies/disk.yml", false},
+		{"", false},
+		{"FLEETS/x.yml", false}, // case-sensitive
+	}
+	for _, c := range cases {
+		if got := HasPrefix(c.path); got != c.want {
+			t.Errorf("HasPrefix(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Brings fleet-plan up to date with the current Fleet GitOps schema so it runs cleanly against repos generated by recent `fleetctl gitops`. Six independent changes; happy to split into separate PRs if you'd prefer to land them piecemeal.

### 1. `fleets/` directory support (commit aa72a42)

Fleet renamed the per-team YAML directory from `teams/` to `fleets/` in fleetdm/fleet#40726 ("Migrating teams to fleets and queries to reports"). New repos generated by `fleetctl new` use `fleets/`. fleet-plan was hard-coding `teams/` everywhere.

Adds a new `internal/teamdir` package as the single source of truth that resolves the directory at runtime, preferring `fleets/` when both exist. Four call sites consult it: `parser.ParseRepo`, `git.ResolveScope`, `git.CheckoutBaseline`, and the CLI's "no teams found" error.

### 2. `controls.apple_settings.configuration_profiles` parsing (commit c07e212)

The unified Apple-platform block introduced in Fleet 4.x. Replaces the legacy `controls.macos_settings.custom_settings`. Entries may be `.mobileconfig` (macOS/iOS/iPadOS), `.json` (DDM declarations), or `.xml`. Without this, every team in a modern repo parses with `profiles=0`, and `diffProfiles` reports every live Fleet profile as REMOVED — silent data-loss-shaped output.

Platform on the parsed profile is inferred from the path segment: `lib/macos/` → darwin, `lib/ipados/` → ipados, `lib/ios/` → ios, everything else → darwin. The diff identity (profile name from the file content or filename) is unchanged.

### 3. Top-level `settings:` key (commit c07e212)

Valid in current Fleet GitOps yaml but fleet-plan was rejecting it as `unknown top-level key`. Now parsed opaquely — field-level diffing of this section isn't implemented yet, but the absence of an error keeps the rest of the diff (profiles, policies, queries, software) trustworthy.

Also captures `labels_include_any` / `labels_exclude_any` / `labels_include_all` sibling keys on profile refs (previously dropped silently).

### 4. Depth-aware top-level `PayloadDisplayName` extraction (commit 4fc400e)

`extractMobileconfigName` previously kept the **last** PayloadDisplayName in the file, on the assumption that the top-level one always appears after `PayloadContent`. That holds for plists produced by some generators (ProfileCreator), but Apple Configurator and most hand-edited profiles put the top-level PayloadDisplayName **before** PayloadContent — where the "last" occurrence is a deeply-nested payload's display name, not the profile's identity.

The bug surfaces dramatically with template-derived profiles: e.g. 50 per-location Zoom Room activation profiles with unique outer names (`"… — University of Pennsylvania (Room2)"`) but identical nested payload names (`"Zoom Room Activation Code (Mac)"`) all collapse to one duplicate name, producing a fake ADDED/REMOVED storm.

New extractor streams through the XML with a `<dict>` nesting depth counter and only accepts PayloadDisplayName at depth 1 (direct child of the root dict). Position within the file no longer matters. Existing tests covering top-level-last ordering still pass.

### 5. `reports:` aliases `queries:` (commit 32770f0)

Same fleetdm/fleet#40726 that renamed `teams/` → `fleets/` also renamed the team-yaml key `queries:` → `reports:`. `fleetctl gitops` accepts both during the transition, so fleet-plan should too. Previously `reports:` was accepted opaquely (no error), but the query `path:` refs underneath were silently dropped — so a team listing 2 queries under `reports:` parsed with 0 queries on the proposed side, and live Fleet's queries showed as REMOVED.

`rawTeamFile.Reports` and the matching field in the `default.yml` raw struct now feed the same `resolveQueryRef` loop. Both keys remain valid and produce equivalent output.

### 6. `windows_settings.configuration_profiles` + list-form package files (commit d97e1e1)

Two more false-REMOVED sources surfaced by a later PR (both confirmed against the live API; neither is label-scoping, despite the affected resources all carrying `labels_include_any`):

- **Windows `configuration_profiles`.** `parseTeamFile` read only `controls.windows_settings.custom_settings`. Fleet also accepts `controls.windows_settings.configuration_profiles` — the Windows counterpart of the `apple_settings.configuration_profiles` block from #2. Profiles defined there never reached the proposed side, so every matching live Fleet profile was reported REMOVED. (Observed: 5 Windows `.xml` profiles flagged REMOVED while `fleetctl gitops --dry-run` deleted nothing.)
- **List-form package files.** `resolveSoftwareRef` unmarshaled a package YAML only as a single object (`url: ...`). A package file written as a one-element sequence (`- url: ...`) — which `fleetctl gitops` accepts — failed to unmarshal, dropping the package and reporting it REMOVED. `resolvePolicyRef`/`resolveQueryRef` already tolerate both forms; this brings the software resolver in line.

Both Windows profile spellings (`custom_settings`, `configuration_profiles`) and both package shapes now parse equivalently.

## Why now

I wired fleet-plan into a real Fleet GitOps repo's PR workflow. Each substantive PR surfaced another schema gap:

1. First substantive PR: 53 profiles reported as REMOVED → root cause was the `controls.macos_settings.custom_settings` → `controls.apple_settings.configuration_profiles` rename (#2 above) plus the unknown top-level keys (#3).
2. After fixing #2 and #3, the same PR was reporting 50+ profiles ADDED with duplicate names → root cause was the top-level-last assumption in `extractMobileconfigName` (#4).
3. After fixing #4, the PR was still reporting 2 queries as REMOVED → root cause was the `queries:` → `reports:` rename (#5).
4. A later PR (whose only real change was one macOS profile) reported 5 Windows profiles + 1 package as REMOVED → root cause was the unparsed `windows_settings.configuration_profiles` key and the list-form package file (#6).

The schema gaps are load-bearing — without them the tool is dangerous, not just incomplete.

The existing `teams/`, legacy-controls, and legacy-`queries:` code paths are all unchanged and still exercised by every pre-existing test.

End-to-end validation against a real Fleet instance:

- A clean branch (matches live state): `No changes detected. Your branch matches the current Fleet state.` ✅
- A substantive PR adding one declaration profile: `1 added` (just the new profile) ✅
- A PR touching one macOS profile: only that profile is reported; the Windows profiles and the list-form package that previously showed REMOVED are now correctly matched as unchanged ✅

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — existing tests still pass, plus new tests:
  - `internal/teamdir`: resolve / precedence / `HasPrefix`
  - `parser.TestParseRepoFleetsDir`
  - `parser.TestParseRepoFleetsTakesPriorityOverTeams`
  - `parser.TestParseRepoAppleSettings` — covers `.mobileconfig` + DDM `.json` + platform inference
  - `parser.TestParseRepoAcceptsSettingsKey`
  - `parser.TestParseRepoReportsAliasesQueries` — verifies `reports:` path refs become team queries
  - `parser.TestParseRepoWindowsConfigurationProfiles` — verifies `windows_settings.configuration_profiles` (incl. a label-scoped entry) is parsed with `platform=windows`
  - `parser.TestParseSoftwarePackageListForm` — verifies a single-element-list package file parses identically to the object form
  - `parser.TestExtractMobileconfigName` — adds a top-level-first case alongside the existing top-level-last and real-world cases
  - `git.TestIsTeamYAML`
  - `git.TestResolveScope` — new cases for `fleets/` team-file and resource changes
- [x] End-to-end against a real Fleet instance: all 8 teams in a real `fleets/`-based repo parse with zero errors, profile and query counts match live Fleet state, and the diff output for a substantive PR is now accurate.

Happy to adjust naming, structure, or split this up however you'd like. Thanks for the tool!
